### PR TITLE
Add --user-agent command line option

### DIFF
--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -22,6 +22,7 @@ type Chrome struct {
 	Resolution    string
 	ChromeTimeout int
 	Path          string
+	UserAgent     string
 
 	ScreenshotPath string
 }
@@ -148,8 +149,7 @@ func (chrome *Chrome) ScreenshotURL(targetURL *url.URL, destination string) {
 	var chromeArguments = []string{
 		"--headless", "--disable-gpu", "--hide-scrollbars",
 		"--disable-crash-reporter",
-		"--user-agent='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
-			"(KHTML, like Gecko) Chrome/60.0.3112.50 Safari/537.36'",
+		"--user-agent=" + chrome.UserAgent,
 		"--window-size=" + chrome.Resolution, "--screenshot=" + destination,
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ var (
 	resolution    string
 	chromeTimeout int
 	chromePath    string
+	userAgent     string
 
 	// screenshot command flags
 	screenshotURL         string
@@ -71,6 +72,7 @@ var RootCmd = &cobra.Command{
 			Resolution:    resolution,
 			ChromeTimeout: chromeTimeout,
 			Path:          chromePath,
+			UserAgent:     userAgent,
 		}
 		chrome.Setup()
 
@@ -106,6 +108,7 @@ func init() {
 	RootCmd.PersistentFlags().IntVarP(&waitTimeout, "timeout", "T", 3, "Time in seconds to wait for a HTTP connection")
 	RootCmd.PersistentFlags().IntVarP(&chromeTimeout, "chrome-timeout", "", 90, "Time in seconds to wait for Google Chrome to finish a screenshot")
 	RootCmd.PersistentFlags().StringVarP(&chromePath, "chrome-path", "", "", "Full path to the Chrome executable to use. By default, gowitness will search for Google Chrome")
+	RootCmd.PersistentFlags().StringVarP(&userAgent, "user-agent", "", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.50 Safari/537.36", "Alernate UserAgent string to use for Google Chrome")
 	RootCmd.PersistentFlags().StringVarP(&resolution, "resolution", "R", "1440,900", "screenshot resolution")
 	RootCmd.PersistentFlags().StringVarP(&screenshotDestination, "destination", "d", ".", "Destination directory for screenshots")
 	RootCmd.PersistentFlags().StringVarP(&dbLocation, "db", "D", "gowitness.db", "Destination for the gowitness database")

--- a/utils/processor.go
+++ b/utils/processor.go
@@ -32,7 +32,7 @@ func ProcessURL(url *url.URL, chrome *chrm.Chrome, db *storage.Storage, timeout 
 
 	request := gorequest.New().Timeout(time.Duration(timeout)*time.Second).
 		TLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
-		Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.50 Safari/537.36")
+		Set("User-Agent", chrome.UserAgent)
 
 	resp, _, errs := request.Get(url.String()).End()
 	if errs != nil {


### PR DESCRIPTION
Adds a command line option to specify an alternate user-agent string.  