### PR TITLE
Add --virtual-time-budget chrome parameter to wait beyond page load

### DIFF
--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -19,10 +19,11 @@ import (
 // Chrome contains information about a Google Chrome
 // instance, with methods to run on it.
 type Chrome struct {
-	Resolution    string
-	ChromeTimeout int
-	Path          string
-	UserAgent     string
+	Resolution       string
+	ChromeTimeout    int
+	ChromeTimeBudget string
+	Path             string
+	UserAgent        string
 
 	ScreenshotPath string
 }
@@ -151,7 +152,7 @@ func (chrome *Chrome) ScreenshotURL(targetURL *url.URL, destination string) {
 		"--disable-crash-reporter",
 		"--user-agent=" + chrome.UserAgent,
 		"--window-size=" + chrome.Resolution, "--screenshot=" + destination,
-		"--virtual-time-budget=10000",
+		"--virtual-time-budget=" + chrome.ChromeTimeBudget,
 	}
 
 	// When we are running as root, chromiun will flag the 'cant

--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -151,6 +151,7 @@ func (chrome *Chrome) ScreenshotURL(targetURL *url.URL, destination string) {
 		"--disable-crash-reporter",
 		"--user-agent=" + chrome.UserAgent,
 		"--window-size=" + chrome.Resolution, "--screenshot=" + destination,
+		"--virtual-time-budget=10000",
 	}
 
 	// When we are running as root, chromiun will flag the 'cant

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,11 +27,12 @@ var (
 	logFormat string
 
 	// 'global' flags
-	waitTimeout   int
-	resolution    string
-	chromeTimeout int
-	chromePath    string
-	userAgent     string
+	waitTimeout      int
+	resolution       string
+	chromeTimeout    int
+	chromeTimeBudget string
+	chromePath       string
+	userAgent        string
 
 	// screenshot command flags
 	screenshotURL         string
@@ -69,10 +70,11 @@ var RootCmd = &cobra.Command{
 
 		// Init Google Chrome
 		chrome = chrm.Chrome{
-			Resolution:    resolution,
-			ChromeTimeout: chromeTimeout,
-			Path:          chromePath,
-			UserAgent:     userAgent,
+			Resolution:       resolution,
+			ChromeTimeout:    chromeTimeout,
+			ChromeTimeBudget: chromeTimeBudget,
+			Path:             chromePath,
+			UserAgent:        userAgent,
 		}
 		chrome.Setup()
 
@@ -107,6 +109,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gowitness.yaml)")
 	RootCmd.PersistentFlags().IntVarP(&waitTimeout, "timeout", "T", 3, "Time in seconds to wait for a HTTP connection")
 	RootCmd.PersistentFlags().IntVarP(&chromeTimeout, "chrome-timeout", "", 90, "Time in seconds to wait for Google Chrome to finish a screenshot")
+	RootCmd.PersistentFlags().StringVarP(&chromeTimeBudget, "chrome-time-budget", "", "500", "Time in milliseconds to wait for pending network requests when loading a page in Google Chrome")
 	RootCmd.PersistentFlags().StringVarP(&chromePath, "chrome-path", "", "", "Full path to the Chrome executable to use. By default, gowitness will search for Google Chrome")
 	RootCmd.PersistentFlags().StringVarP(&userAgent, "user-agent", "", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.50 Safari/537.36", "Alernate UserAgent string to use for Google Chrome")
 	RootCmd.PersistentFlags().StringVarP(&resolution, "resolution", "R", "1440,900", "screenshot resolution")


### PR DESCRIPTION
I've been having issues with sites that take a bit longer to fully load beyond the page load event firing. I've did some digging and it looks like the --virtual-time-budget parameter allows you to specify how much time to wait for pending network requests to finish. 

The main example is autodiscover sites for outlook:
Pre PR
![http-autodiscover outlook com-pre-PR](https://user-images.githubusercontent.com/962226/57402941-77354380-71a6-11e9-9989-81e59da09721.png)

Post PR
![http-autodiscover outlook com-post-PR](https://user-images.githubusercontent.com/962226/57402940-77354380-71a6-11e9-95bd-ced3e3931554.png)

