### PR TITLE
Add experimental proxy support via envvar HTTP_PROXY

### DIFF
--- a/utils/processor.go
+++ b/utils/processor.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -30,9 +31,20 @@ func ProcessURL(url *url.URL, chrome *chrm.Chrome, db *storage.Storage, timeout 
 	// prepare a storage instance for this URL
 	log.WithField("url", url).Debug("Processing URL")
 
-	request := gorequest.New().Timeout(time.Duration(timeout)*time.Second).
-		TLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
-		Set("User-Agent", chrome.UserAgent)
+	// proxy hack start here
+	var request *gorequest.SuperAgent
+	proxyUrl := os.Getenv(`HTTP_PROXY`)
+
+	if proxyUrl != "" {
+		// *Dont* verify remote certificates.
+		request = gorequest.New().Proxy(proxyUrl).Timeout(time.Duration(timeout)*time.Second).
+			TLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
+			Set("User-Agent", chrome.UserAgent)
+	} else {
+		request = gorequest.New().Proxy(proxyUrl).Timeout(time.Duration(timeout)*time.Second).
+			TLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
+			Set("User-Agent", chrome.UserAgent)
+	}
 
 	resp, _, errs := request.Get(url.String()).End()
 	if errs != nil {


### PR DESCRIPTION
Hello guys, really enjoy using gowitness. I needed to use gowitness with a proxy, so I thought I would add support directly to gowitness instead of relying on another tool to proxy it.

Commit msg below:

Adds proxy support to the initial redirect check with
gorequest and the chrome browser. It also always
forwards to shitty forwarding proxy regardless of
protocol.  This change made it easier to add a
proxy to both http and https.

You can use the proxy like
`export HTTP_PROXY=http://127.1:8080;gowitness ...`