### PR TITLE
Added --output parameter for single command

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -93,7 +93,7 @@ $ gowitness file --source ~/Desktop/urls --threads -2
 
 				defer swg.Done()
 
-				utils.ProcessURL(url, &chrome, &db, waitTimeout)
+				utils.ProcessURL(url, &chrome, &db, waitTimeout, "")
 
 				// update the progress bar
 				atomic.AddInt64(&status.Done, 1)

--- a/cmd/nmap.go
+++ b/cmd/nmap.go
@@ -115,7 +115,7 @@ $ gowitness nmap --nmap-file nmap.xml -s -n http`,
 
 				defer swg.Done()
 
-				utils.ProcessURL(url, &chrome, &db, waitTimeout)
+				utils.ProcessURL(url, &chrome, &db, waitTimeout, "")
 
 				// update the progress bar
 				atomic.AddInt64(&status.Done, 1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ var (
 	// screenshot command flags
 	screenshotURL         string
 	screenshotDestination string
+	outputFile            string
 
 	// file scanner command flags
 	sourceFile  string

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -182,7 +182,7 @@ $ gowitness scan --ports 80,443,8080 --cidr 192.168.0.0/30 --append-uri-file ~/w
 
 				defer swg.Done()
 
-				utils.ProcessURL(url, &chrome, &db, waitTimeout)
+				utils.ProcessURL(url, &chrome, &db, waitTimeout, "")
 
 				// update the progress bar
 				atomic.AddInt64(&status.Done, 1)

--- a/cmd/single.go
+++ b/cmd/single.go
@@ -16,14 +16,18 @@ var singleCmd = &cobra.Command{
 	Short: "Take a screenshot of a single URL",
 	Long: `
 Takes a screenshot of a single given URL and saves it to a file.
-If no --destination is provided, a filename for the screenshot will
-be automatically generated based on the given URL.
+If no --output is provided, a filename for the screenshot will
+be automatically generated based on the given URL. If an absolute
+output file path is given, the --destination parameter will be
+ignored.
 
 For example:
 
 $ gowitness single --url https://twitter.com
-$ gowitness single --destination tweeps_page.png --url https://twitter.com
-$ gowitness single -u https://twitter.com`,
+$ gowitness single --destination ~/tweeps_dir --url https://twitter.com
+$ gowitness single -u https://twitter.com
+$ gowitness single -o /screenshots/twitter.png -u https://twitter.com
+$ gowitness single --destination ~/screenshots -o twitter.png -u https://twitter.com`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 
@@ -33,7 +37,7 @@ $ gowitness single -u https://twitter.com`,
 		}
 
 		// Process this URL
-		utils.ProcessURL(u, &chrome, &db, waitTimeout)
+		utils.ProcessURL(u, &chrome, &db, waitTimeout, outputFile)
 
 		log.WithFields(log.Fields{"run-time": time.Since(startTime)}).Info("Complete")
 	},
@@ -43,4 +47,5 @@ func init() {
 	RootCmd.AddCommand(singleCmd)
 
 	singleCmd.Flags().StringVarP(&screenshotURL, "url", "u", "", "The URL to screenshot")
+	singleCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write the screenshot to this file")
 }

--- a/utils/processor.go
+++ b/utils/processor.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"crypto/tls"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -109,8 +108,7 @@ func ProcessURL(url *url.URL, chrome *chrm.Chrome, db *storage.Storage, timeout 
 		if filepath.IsAbs(fname) {
 			dst = fname
 		} else {
-			pwd, _ := os.Getwd()
-			dst = filepath.Join(pwd, fname)
+			dst = filepath.Join(chrome.ScreenshotPath, fname)
 		}
 	}
 

--- a/utils/processor.go
+++ b/utils/processor.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -23,7 +24,7 @@ const (
 )
 
 // ProcessURL processes a URL
-func ProcessURL(url *url.URL, chrome *chrm.Chrome, db *storage.Storage, timeout int) {
+func ProcessURL(url *url.URL, chrome *chrm.Chrome, db *storage.Storage, timeout int, outputFile string) {
 
 	// prepare some storage for this URL
 	HTTPResponseStorage := storage.HTTResponse{URL: url.String()}
@@ -98,11 +99,20 @@ func ProcessURL(url *url.URL, chrome *chrm.Chrome, db *storage.Storage, timeout 
 		log.WithFields(log.Fields{"url": url, "cipher-suite": resp.TLS.CipherSuite}).Info("Cipher suite in use")
 	}
 
-	// Generate a safe filename to use
-	fname := SafeFileName(url.String()) + ".png"
-
-	// Get the full path where we will be saving the screenshot to
-	dst := filepath.Join(chrome.ScreenshotPath, fname)
+	// Generate a safe filename and a destination to use
+	var fname, dst string
+	if outputFile == "" {
+		fname = SafeFileName(url.String()) + ".png"
+		dst = filepath.Join(chrome.ScreenshotPath, fname)
+	} else {
+		fname = outputFile
+		if filepath.IsAbs(fname) {
+			dst = fname
+		} else {
+			pwd, _ := os.Getwd()
+			dst = filepath.Join(pwd, fname)
+		}
+	}
 
 	HTTPResponseStorage.ScreenshotFile = dst
 	log.WithFields(log.Fields{"url": url, "file-name": fname, "destination": dst}).


### PR DESCRIPTION
At the moment it is only possible to set a destination path, but not a destination file. However this is very useful in automated environments.

I added the following behaviour:
If the --output file path is absolute it is used directly.
If the --output file path is relative and the --destination path is set then they are combined.

I only added it for the single command, because I don't think it's useful for other commands.