### PR TITLE
HTTP and Socks5 Proxy Support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,4 +67,5 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&chrm.FullPage, "fullpage", "F", false, "take fullpage screenshots")
 	rootCmd.PersistentFlags().Int64Var(&chrm.Timeout, "timeout", 10, "preflight check timeout")
 	rootCmd.PersistentFlags().StringVarP(&chrm.ChromePath, "chrome-path", "", "", "path to chrome executable to use")
+	rootCmd.PersistentFlags().StringVarP(&chrm.ProxyServer, "proxy-server", "", "", "http/socks5 proxy to use. Use format proto://address:port")
 }


### PR DESCRIPTION
Added HTTP and Socks5 Proxy support to both the Preflight checks and the screenshot.

Preflight: Uses the http.client to make requests, so we've added proxy support via the Dialer objects and the x/proxy library. Could potentially leverage the chromedp library instead of http.client in the future to simplify things.

Screenshot: Uses the built-in chromedp.ProxyServer which passes the "--proxy-server" argument to the chrome binaries. Supports http and socks5 out of the box. 

Could probably use a bit of error handling if someone typo's the proxy URL