### PR TITLE
The screenshot filename doesn't append .png

### DIFF
--- a/cmd/report_serve.go
+++ b/cmd/report_serve.go
@@ -86,7 +86,7 @@ func submitHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		fn := lib.SafeFileName(url.String())
+		fn := lib.SafeFileName(url.String()) + ".png"
 		fp := lib.ScreenshotPath(fn, url, options.ScreenshotPath)
 
 		resp, title, err := chrm.Preflight(url)

--- a/cmd/report_serve.go
+++ b/cmd/report_serve.go
@@ -86,7 +86,7 @@ func submitHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		fn := lib.SafeFileName(url.String()) + ".png"
+		fn := lib.SafeFileName(url.String())
 		fp := lib.ScreenshotPath(fn, url, options.ScreenshotPath)
 
 		resp, title, err := chrm.Preflight(url)

--- a/web/assets/templates/detail.html
+++ b/web/assets/templates/detail.html
@@ -49,7 +49,7 @@
           <div class="card-body">
             <p><kbd>{{ .URL }}</kbd> responded with <kbd>{{ .ResponseReason}}</kbd></p>
              <div>
-              <a href="{{ .URL }}" target="_blank" class="btn btn-light">Open URL in Browser</a>
+              <a href="{{ .URL }}" target="_blank" class="btn btn-light">Open URL</a>
             </div>
           </div>
         </div>

--- a/web/assets/templates/detail.html
+++ b/web/assets/templates/detail.html
@@ -18,7 +18,7 @@
 
   <div class="col-sm-6 col-lg-4">
     <div class="card card-sm">
-      <a href="/screenshots/{{ .Filename }}" class="d-block">
+      <a href="{{ .URL }}" target="_blank" class="d-block">
         <img loading="lazy" src="/screenshots/{{ .Filename }}" 
              onerror="this.onerror=null; this.src='/assets/img/blank.png'" class="card-img-top">
       </a>
@@ -48,6 +48,9 @@
           </div>
           <div class="card-body">
             <p><kbd>{{ .URL }}</kbd> responsed with <kbd>{{ .ResponseReason}}</kbd></p>
+             <div>
+              <a href="/screenshots/{{ .Filename }}" target="_blank" class="btn btn-light">View Screenshot</a>
+            </div>
           </div>
         </div>
       </div>

--- a/web/assets/templates/detail.html
+++ b/web/assets/templates/detail.html
@@ -47,7 +47,7 @@
             <h3 class="card-title">Summary</h3>
           </div>
           <div class="card-body">
-            <p><kbd>{{ .URL }}</kbd> responsed with <kbd>{{ .ResponseReason}}</kbd></p>
+            <p><kbd>{{ .URL }}</kbd> responded with <kbd>{{ .ResponseReason}}</kbd></p>
              <div>
               <a href="/screenshots/{{ .Filename }}" target="_blank" class="btn btn-light">View Screenshot</a>
             </div>

--- a/web/assets/templates/detail.html
+++ b/web/assets/templates/detail.html
@@ -18,7 +18,7 @@
 
   <div class="col-sm-6 col-lg-4">
     <div class="card card-sm">
-      <a href="{{ .URL }}" target="_blank" class="d-block">
+      <a href="/screenshots/{{ .Filename }}" target="_blank" class="d-block">
         <img loading="lazy" src="/screenshots/{{ .Filename }}" 
              onerror="this.onerror=null; this.src='/assets/img/blank.png'" class="card-img-top">
       </a>
@@ -49,7 +49,7 @@
           <div class="card-body">
             <p><kbd>{{ .URL }}</kbd> responded with <kbd>{{ .ResponseReason}}</kbd></p>
              <div>
-              <a href="/screenshots/{{ .Filename }}" target="_blank" class="btn btn-light">View Screenshot</a>
+              <a href="{{ .URL }}" target="_blank" class="btn btn-light">Open URL in Browser</a>
             </div>
           </div>
         </div>

--- a/web/assets/templates/gallery.html
+++ b/web/assets/templates/gallery.html
@@ -45,15 +45,16 @@
   {{ range .Records}}
 
   <div class="col-sm-6 col-lg-4">
-    <div class="card card-sm">
+    <div class="card card-sm" style="position: relative">
       <a href="/screenshots/{{ .Filename }}" class="d-block">
         <img loading="lazy" src="/screenshots/{{ .Filename }}" 
              onerror="this.onerror=null; this.src='/assets/img/blank.png'" class="card-img-top">
       </a>
+      <div style="position: absolute; top: 2px; right: 4px;"><a href="{{ .URL }}" target="_blank" class="btn btn-dark btn-sm"><span><svg class="w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122"></path></svg> Open</span></a></div>
       <div class="card-body">
         <div class="d-flex align-items-center">
           <div class="lh-sm">
-            <div>{{ .URL }}</div>
+            <div><a href="{{ .URL }}">{{ .URL }}</a></div>
             <div class="text-muted">{{ .Title }}</div>
           </div>
           <div class="ml-auto">

--- a/web/assets/templates/gallery.html
+++ b/web/assets/templates/gallery.html
@@ -46,7 +46,7 @@
 
   <div class="col-sm-6 col-lg-4">
     <div class="card card-sm">
-      <a href="/screenshots/{{ .Filename }}" class="d-block">
+      <a href="{{ .URL }}" class="d-block">
         <img loading="lazy" src="/screenshots/{{ .Filename }}" 
              onerror="this.onerror=null; this.src='/assets/img/blank.png'" class="card-img-top">
       </a>

--- a/web/assets/templates/gallery.html
+++ b/web/assets/templates/gallery.html
@@ -46,7 +46,7 @@
 
   <div class="col-sm-6 col-lg-4">
     <div class="card card-sm">
-      <a href="{{ .URL }}" class="d-block">
+      <a href="/screenshots/{{ .Filename }}" class="d-block">
         <img loading="lazy" src="/screenshots/{{ .Filename }}" 
              onerror="this.onerror=null; this.src='/assets/img/blank.png'" class="card-img-top">
       </a>


### PR DESCRIPTION
The SafeFileName method doesn't append .png to the screenshot filename url, so manually appending it so that upon clicking the image can be rendered in the browser rather than downloaded.