### PR TITLE
Add API endpoint

### DIFF
--- a/cmd/report_serve.go
+++ b/cmd/report_serve.go
@@ -93,6 +93,7 @@ func init() {
 	reportServeCmd.Flags().BoolVarP(&options.AllowInsecureURIs, "allow-insecure-uri", "A", false, "allow uris that dont start with http(s)")
 }
 
+// takes a screenshot of the requested url
 func takeScreenshot(rUrl string, fn string) (uint, error) {
 	url, err := url.Parse(rUrl)
 	if err != nil {

--- a/cmd/report_serve.go
+++ b/cmd/report_serve.go
@@ -19,8 +19,8 @@ import (
 )
 
 type ApiRequest struct {
-    Name string
-    Url  string
+	Name string
+	Url  string
 }
 
 var (
@@ -129,7 +129,7 @@ func submitHandler(w http.ResponseWriter, r *http.Request) {
 
 		var rid uint
 		if rsDB != nil {
-                if rid, err = chrm.StorePreflight(url, rsDB, resp, title, fn); err != nil {
+			if rid, err = chrm.StorePreflight(url, rsDB, resp, title, fn); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -165,15 +165,15 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"success": false, "message": "only POST requests are accepted"}`))
 		return
 	case "POST":
-	    var p ApiRequest
+		var p ApiRequest
 
-        err := json.NewDecoder(r.Body).Decode(&p)
-        if err != nil {
-            w.Header().Set("Content-Type", "application/json")
-            w.WriteHeader(http.StatusInternalServerError)
-            w.Write([]byte(fmt.Sprintf(`{"success": false, "message": "%s"}`, err.Error())))
-            return
-        }
+		err := json.NewDecoder(r.Body).Decode(&p)
+		if err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(fmt.Sprintf(`{"success": false, "message": "%s"}`, err.Error())))
+			return
+		}
 
 		// prepare target
 		url, err := url.Parse(strings.TrimSpace(p.Url))
@@ -196,7 +196,7 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 		// defer execution
 		go func() {
 			fn := p.Name
-			if fn == ""  {
+			if fn == "" {
 				fn = lib.SafeFileName(url.String())
 			} else if !strings.HasSuffix(fn, ".png") {
 				fn = fn + ".png"

--- a/cmd/report_serve.go
+++ b/cmd/report_serve.go
@@ -195,6 +195,8 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 
 		// defer execution
 		go func() {
+			log := options.Logger
+
 			fn := p.Name
 			if fn == "" {
 				fn = lib.SafeFileName(url.String())
@@ -205,22 +207,26 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 
 			resp, title, err := chrm.Preflight(url)
 			if err != nil {
+				log.Error().Err(err).Msg("Unexpected error occurred")
 				return
 			}
 
 			var rid uint
 			if rsDB != nil {
 				if rid, err = chrm.StorePreflight(url, rsDB, resp, title, fn); err != nil {
+					log.Error().Err(err).Msg("Failed to save in database")
 					return
 				}
 			}
 
 			buf, err := chrm.Screenshot(url)
 			if err != nil {
+				log.Error().Err(err).Msg("Failed to take screenshot")
 				return
 			}
 
 			if err := ioutil.WriteFile(fp, buf, 0644); err != nil {
+				log.Error().Err(err).Msg("Failed to save screenshot")
 				return
 			}
 

--- a/cmd/report_serve.go
+++ b/cmd/report_serve.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-    "fmt"
+	"fmt"
 	"html/template"
 	"io/ioutil"
 	"net/http"
@@ -154,63 +154,63 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case "GET":
-        w.Header().Set("Content-Type", "application/json")
-        w.WriteHeader(http.StatusMethodNotAllowed)
-        w.Write([]byte(`{"success": false, "message": "only POST requests are accepted"}`))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte(`{"success": false, "message": "only POST requests are accepted"}`))
 		return
 	case "POST":
 		// prepare target
 		url, err := url.Parse(strings.TrimSpace(r.FormValue("url")))
 		if err != nil {
-            w.Header().Set("Content-Type", "application/json")
-            w.WriteHeader(http.StatusInternalServerError)
-            w.Write([]byte(fmt.Sprintf(`{"success": false, "message": "%s"}`, err.Error())))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(fmt.Sprintf(`{"success": false, "message": "%s"}`, err.Error())))
 			return
 		}
 
 		if !options.AllowInsecureURIs {
 			if !strings.HasPrefix(url.Scheme, "http") {
 				w.Header().Set("Content-Type", "application/json")
-                w.WriteHeader(http.StatusNotAcceptable)
-                w.Write([]byte(`{"success": false, "message": "only http(s) urls are accepted"}`))
+				w.WriteHeader(http.StatusNotAcceptable)
+				w.Write([]byte(`{"success": false, "message": "only http(s) urls are accepted"}`))
 				return
 			}
 		}
 
-        // Defer execution
-        go func() {
-            fn := lib.SafeFileName(url.String())
-            fp := lib.ScreenshotPath(fn, url, options.ScreenshotPath)
+		// Defer execution
+		go func() {
+			fn := lib.SafeFileName(url.String())
+			fp := lib.ScreenshotPath(fn, url, options.ScreenshotPath)
 
-            resp, title, err := chrm.Preflight(url)
-            if err != nil {
-                return
-            }
+			resp, title, err := chrm.Preflight(url)
+			if err != nil {
+				return
+			}
 
-            var rid uint
-            if rsDB != nil {
-                if rid, err = chrm.StorePreflight(url, rsDB, resp, title, fn); err != nil {
-                    return
-                }
-            }
+			var rid uint
+			if rsDB != nil {
+				if rid, err = chrm.StorePreflight(url, rsDB, resp, title, fn); err != nil {
+					return
+				}
+			}
 
-            buf, err := chrm.Screenshot(url)
-            if err != nil {
-                return
-            }
+			buf, err := chrm.Screenshot(url)
+			if err != nil {
+				return
+			}
 
-            if err := ioutil.WriteFile(fp, buf, 0644); err != nil {
-                return
-            }
+			if err := ioutil.WriteFile(fp, buf, 0644); err != nil {
+				return
+			}
 
-            if rid > 0 {
-                return
-            }
+			if rid > 0 {
+				return
+			}
 		}()
 
-        w.Header().Set("Content-Type", "application/json")
-        w.WriteHeader(http.StatusOK)
-        w.Write([]byte(`{"success": true}`))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"success": true}`))
 		return
 	}
 }


### PR DESCRIPTION
Added a API endpoint to submit urls at `/api`. The endpoint uses json responses. 

We had a specific use case where we wanted to run a single instance of gowitness and programmatically submit urls to it. While the endpoint `/submit` works, it doesn't return a response until the screenshot is done.

Custom filename can specified in `name`. If `.png` extension is not present, it will automatically add it.

Example Request:
```sh
curl -X POST -H "Content-Type: application/json" http://127.0.0.1:7171/api -d '{"url": "https://www.google.com", "name": "test.png"}'
```
Response:
```json
{"success": true}
```
Errors:
```json
{"success": false, "message": "only POST requests are accepted"}
{"success": false, "message": "only http(s) urls are accepted"}
```