### PR TITLE
Reuse same wappalyzer client across requests

### DIFF
--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
+	wappalyzer "github.com/projectdiscovery/wappalyzergo"
 	"github.com/sensepost/gowitness/storage"
 	"gorm.io/gorm"
 )
@@ -25,6 +26,14 @@ type Chrome struct {
 	FullPage    bool
 	ChromePath  string
 	Proxy       string
+}
+
+var wappalyzerClient *wappalyzer.Wappalyze
+
+func InitWappalyzer() error {
+	var err error
+	wappalyzerClient, err = wappalyzer.New()
+	return err
 }
 
 // NewChrome returns a new initialised Chrome struct

--- a/chrome/helpers.go
+++ b/chrome/helpers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	wappalyzer "github.com/projectdiscovery/wappalyzergo"
 	"golang.org/x/net/html"
 )
 
@@ -51,7 +50,6 @@ func GetHTMLTitle(r io.Reader) (string, bool) {
 // GetTechnologies uses wapalyzer signatures to return an array
 // of technologies that are in use by the remote site.
 func GetTechnologies(resp *http.Response) ([]string, error) {
-
 	var technologies []string
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -59,13 +57,7 @@ func GetTechnologies(resp *http.Response) ([]string, error) {
 		return technologies, err
 	}
 
-	wappalyzerClient, err := wappalyzer.New()
-	if err != nil {
-		return technologies, err
-	}
-
 	fingerprints := wappalyzerClient.Fingerprint(resp.Header, data)
-
 	for match := range fingerprints {
 		technologies = append(technologies, match)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,8 +28,10 @@ var rootCmd = &cobra.Command{
 	Use:   "gowitness",
 	Short: "A commandline web screenshot and information gathering tool by @leonjza",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-
 		// Setup the logger to use
+		if err := chrome.InitWappalyzer(); err != nil {
+			panic(fmt.Sprintf("Could not init wappalyzer: %s\n", err))
+		}
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "02 Jan 2006 15:04:05"})
 		if options.Debug {
 			log.Logger = log.Logger.Level(zerolog.DebugLevel)


### PR DESCRIPTION
Added a fix to reuse the same wappalyzer client across requests. Since the regexes are compiled each time `New()` function is called, it is more performant to do it once in the beginning. 