### PR TITLE
Additional Header Support via JSON

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -44,6 +44,11 @@ $ gowitness file -f <( shuf domains ) --no-http`,
 			log.Fatal().Err(err).Msg("failed to prepare the screenshot path")
 		}
 
+		// parse headers
+		if err = chrm.PrepareHeaderJSONMap(); err != nil {
+			log.Fatal().Err(err).Msg("additional header JSON parsing failed, check the format")
+		}
+
 		for scanner.Scan() {
 			candidate := scanner.Text()
 			if candidate == "" {

--- a/cmd/nessus.go
+++ b/cmd/nessus.go
@@ -73,6 +73,11 @@ $ gowitness nessus -file output.nessus --port 80 --port 8080`,
 			log.Fatal().Err(err).Msg("failed to prepare the screenshot path")
 		}
 
+		// parse headers
+		if err = chrm.PrepareHeaderJSONMap(); err != nil {
+			log.Fatal().Err(err).Msg("additional header JSON parsing failed, check the format")
+		}
+
 		// prepare db
 		db, err := db.Get()
 		if err != nil {

--- a/cmd/nmap.go
+++ b/cmd/nmap.go
@@ -65,6 +65,11 @@ $ gowitness nmap --nmap-file nmap.xml -s -n http`,
 			log.Fatal().Err(err).Msg("failed to prepare the screenshot path")
 		}
 
+		// parse headers
+		if err = chrm.PrepareHeaderJSONMap(); err != nil {
+			log.Fatal().Err(err).Msg("additional header JSON parsing failed, check the format")
+		}
+
 		// prepare db
 		db, err := db.Get()
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&chrm.ResolutionY, "resolution-y", "Y", 900, "screenshot resolution y")
 	rootCmd.PersistentFlags().IntVar(&chrm.Delay, "delay", 0, "delay in seconds between navigation and screenshot")
 	rootCmd.PersistentFlags().StringVar(&chrm.UserAgent, "user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36", "user agent string to use")
+	rootCmd.PersistentFlags().StringSliceVar(&chrm.Headers, "header",[]string{}, "Additional HTTP header to set. Supports multiple --header flags")
 	rootCmd.PersistentFlags().StringVarP(&options.ScreenshotPath, "screenshot-path", "P", "screenshots", "store path for screenshots (use . for pwd)")
 	rootCmd.PersistentFlags().BoolVarP(&chrm.FullPage, "fullpage", "F", false, "take fullpage screenshots")
 	rootCmd.PersistentFlags().Int64Var(&chrm.Timeout, "timeout", 10, "preflight check timeout")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -70,6 +70,11 @@ $ gowitness --log-level debug scan --threads 20 --ports 80,443,8080 --no-http --
 			log.Fatal().Err(err).Msg("failed to prepare the screenshot path")
 		}
 
+		// parse headers
+		if err = chrm.PrepareHeaderJSONMap(); err != nil {
+			log.Fatal().Err(err).Msg("additional header JSON parsing failed, check the format")
+		}
+
 		// prepare db
 		db, err := db.Get()
 		if err != nil {

--- a/cmd/single.go
+++ b/cmd/single.go
@@ -42,6 +42,11 @@ $ gowitness single --destination ~/screenshots -o twitter.png https://twitter.co
 			log.Fatal().Err(err).Msg("failed to prepare the screenshot path")
 		}
 
+		// parse headers
+		if err = chrm.PrepareHeaderJSONMap(); err != nil {
+			log.Fatal().Err(err).Msg("additional header JSON parsing failed, check the format")
+		}
+
 		p := &lib.Processor{
 			Logger:             log,
 			Db:                 db,


### PR DESCRIPTION
This pull request is to add additional HTTP header support across both Preflight and Screenshot (chromedp) requests.

As referenced in issue https://github.com/sensepost/gowitness/issues/64 we need changes to both Preflight and Chromedp since they set headers in different ways. 

[chromedp 'network' library was used to add the headers into chromedp's requests](https://github.com/chromedp/examples/blob/master/headers/main.go), using a map. I decided to use a simple JSON structure '{"Header1":"Value","Header2":"Value"}' as the structure as it seems like the cleanest path.

Additionally, I put the JSON parsing within the chrome object to cut down on multiple JSON parsing attempts (as well as concurrent modifications to the map). I'm not 100% sure if this is the best place for it, as you have to add in an additional function check to every parser (single, nmap, etc). Maybe there's a better place to parse and initialize this map?

An example of why this is needed, take the following example URLs:

```
www.kelloggcompany.com
www.ford.com
```

These URL's need the Accept-Language/Accept-Encoding/Accept headers set before a valid preflight request. (Chromedp actually does 'set' these headers automatically, but figured I'd add in the additional header support for it there anyway).

Without any headers, the preflight fails:

![image](https://user-images.githubusercontent.com/51393999/151941349-a0853de8-672e-4109-9d62-d1dc4772ffc2.png)

With additional headers:

`--headers '{"Accept-Language":"en-US","Accept-Encoding":"gzip, deflate","Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9","AAAAA":"BBBBBB"}'`

![image](https://user-images.githubusercontent.com/51393999/151942229-3bbb9144-4ef6-42bc-93e6-21d97fbe2f18.png)

Headers added to the requests: 
![image](https://user-images.githubusercontent.com/51393999/151941740-234a74c1-8ebd-45cf-8dae-82b3f1fbd59a.png)


It might be useful to hard-code a default Accept-Language, Accept-Encoding, Accept values within the preflight requests anyway.. but I haven't tested if that breaks any web apps that do not need the headers. 