### PR TITLE
fix: Allow wappalyzer to correctly use the response body

### DIFF
--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -86,7 +86,7 @@ func (chrome *Chrome) Preflight(url *url.URL) (resp *http.Response, title string
 	body, _ := io.ReadAll(resp.Body)
 
 	title, _ = GetHTMLTitle(bytes.NewReader(body))
-	technologies, _ = GetTechnologies(resp.Header, body)
+	technologies = GetTechnologies(resp.Header, body)
 
 	return
 }

--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -85,7 +85,7 @@ func (chrome *Chrome) Preflight(url *url.URL) (resp *http.Response, title string
 
 	body, _ := io.ReadAll(resp.Body)
 
-	title, _ = GetHTMLTitle(bytes.NewBuffer(body))
+	title, _ = GetHTMLTitle(bytes.NewReader(body))
 	technologies, _ = GetTechnologies(resp.Header, body)
 
 	return

--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -1,8 +1,10 @@
 package chrome
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -80,8 +82,11 @@ func (chrome *Chrome) Preflight(url *url.URL) (resp *http.Response, title string
 	}
 
 	defer resp.Body.Close()
-	title, _ = GetHTMLTitle(resp.Body)
-	technologies, _ = GetTechnologies(resp)
+
+	body, _ := io.ReadAll(resp.Body)
+
+	title, _ = GetHTMLTitle(bytes.NewBuffer(body))
+	technologies, _ = GetTechnologies(resp.Header, body)
 
 	return
 }

--- a/chrome/helpers.go
+++ b/chrome/helpers.go
@@ -48,7 +48,7 @@ func GetHTMLTitle(r io.Reader) (string, bool) {
 
 // GetTechnologies uses wapalyzer signatures to return an array
 // of technologies that are in use by the remote site.
-func GetTechnologies(headers http.Header, body []byte) ([]string, error) {
+func GetTechnologies(headers http.Header, body []byte) []string {
 	var technologies []string
 
 	fingerprints := wappalyzerClient.Fingerprint(headers, body)
@@ -57,5 +57,5 @@ func GetTechnologies(headers http.Header, body []byte) ([]string, error) {
 		technologies = append(technologies, match)
 	}
 
-	return technologies, nil
+	return technologies
 }

--- a/chrome/helpers.go
+++ b/chrome/helpers.go
@@ -2,7 +2,6 @@ package chrome
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -49,15 +48,11 @@ func GetHTMLTitle(r io.Reader) (string, bool) {
 
 // GetTechnologies uses wapalyzer signatures to return an array
 // of technologies that are in use by the remote site.
-func GetTechnologies(resp *http.Response) ([]string, error) {
+func GetTechnologies(headers http.Header, body []byte) ([]string, error) {
 	var technologies []string
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return technologies, err
-	}
+	fingerprints := wappalyzerClient.Fingerprint(headers, body)
 
-	fingerprints := wappalyzerClient.Fingerprint(resp.Header, data)
 	for match := range fingerprints {
 		technologies = append(technologies, match)
 	}


### PR DESCRIPTION
# The Issue

In the master branch of gowitness, the wappalyzer module is used to detect technologies used by a scanned website. However, I found that not all the technologies on the website were being discovered correctly. 

After some investigation, it appeared that the `wappalyzer.Fingerprint` command was always getting a zero-length byte array as the `body` argument. This was due to the `http.Response.Body` already being read previously during `GetHTMLTitle`. When a `http.Response.Body` is read once, it's no longer usable and should be closed; any further reads result in an empty byte array.

# The Fix

Instead of passing the response body around and allowing subfunctions to read it, it's read once as part of `chrome.Preflight`. That byte array is then passed to the relevant subfunctions.

# Test Methodology

Perform a scan using the code from the latest master branch, and another using the modified version. Validate that more technologies are identified in the latter.

# Screenshots

Before the fix:
![2022-02-17-15-51-45](https://user-images.githubusercontent.com/11320431/154570382-b4986942-1485-432c-936a-146d5a76f249.png)

After the fix:
![2022-02-17-15-52-55](https://user-images.githubusercontent.com/11320431/154570401-b7555f7f-fb26-4a87-baf0-cb7a3b23672c.png)




