### PR TITLE
Fixed range selector which created issue with pagination

### DIFF
--- a/web/ui-templates/gallery.html
+++ b/web/ui-templates/gallery.html
@@ -145,7 +145,7 @@
         {{ range $p := .Data.PrevPageRange }}
         <li class="page-item">
           <a class="page-link"
-            href='{{ URL "/gallery" }}?{{ if .Data.Ordered }}perception_sort=true&{{ end }}limit={{ .Data.Limit }}&page={{ $p }}'>
+            href='{{ URL "/gallery" }}?{{ if $.Data.Ordered }}perception_sort=true&{{ end }}limit={{ $.Data.Limit }}&page={{ $p }}'>
             {{ $p }}
           </a>
         </li>
@@ -160,7 +160,7 @@
         {{ range $p := .Data.NextPageRange }}
         <li class="page-item">
           <a class="page-link"
-            href='{{ URL "/gallery" }}?{{ if .Data.Ordered }}perception_sort=true&{{ end }}limit={{ .Data.Limit }}&page={{ $p }}'>
+            href='{{ URL "/gallery" }}?{{ if $.Data.Ordered }}perception_sort=true&{{ end }}limit={{ $.Data.Limit }}&page={{ $p }}'>
             {{ $p }}
           </a>
         </li>


### PR DESCRIPTION
Addresses issue #160 as the .Data selector needs the scope since it's inside of the range. This was a bug introduced in 2.4.2 that was correct in 2.4.1 comparing the diff https://github.com/sensepost/gowitness/compare/2.4.1...2.4.2

Resolves the errors:

```
template: gallery.html:148:50: executing "gallery.html" at <.Data.Ordered>: can't evaluate field Data in type int
template: gallery.html:163:50: executing "gallery.html" at <.Data.Ordered>: can't evaluate field Data in type int 
```

