### PR TITLE
feat: make URLs clickable in static export

### DIFF
--- a/web/static-templates/gallery.html
+++ b/web/static-templates/gallery.html
@@ -41,7 +41,7 @@
           <div class="card-body">
             <div class="d-flex align-items-center">
               <div>
-                <div>{{ .URL }}</div>
+                <div><a href="{{ .URL }}" target="_blank">{{ .URL }}</a></div>
                 <div class="text-muted">{{ .Title }}</div>
                 <div>
                   {{ range .Technologies }}


### PR DESCRIPTION
This commit adds an HTML tag to allow clicking on the URLs in reports that are exported to static HTML.

I kept it inside the existing div tag, and didn't make any changes related to formatting, etc.

Thanks so much for making a great tool and sharing it with the community.