### PR TITLE
Add a feature excute javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 ## introduction
 
+#### I add --jc argument which can add excute javascript when make screenshot
+
 `gowitness` is a website screenshot utility written in Golang, that uses Chrome Headless to generate screenshots of web interfaces using the command line, with a handy report viewer to process results. Both Linux and macOS is supported, with Windows support mostly working.
 
 Inspiration for `gowitness` comes from [Eyewitness](https://github.com/ChrisTruncer/EyeWitness). If you are looking for something with lots of extra features, be sure to check it out along with these [other](https://github.com/afxdub/http-screenshot-html) [projects](https://github.com/breenmachine/httpscreenshot).

--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -236,7 +236,9 @@ func (chrome *Chrome) Screenshot(url *url.URL) (result *ScreenshotResult, err er
 
 	// prepare a new screenshotResult
 	result = &ScreenshotResult{}
-
+	
+	
+	
 	// setup chromedp default options
 	options := []chromedp.ExecAllocatorOption{}
 	options = append(options, chromedp.DefaultExecAllocatorOptions[:]...)
@@ -244,6 +246,11 @@ func (chrome *Chrome) Screenshot(url *url.URL) (result *ScreenshotResult, err er
 	options = append(options, chromedp.DisableGPU)
 	options = append(options, chromedp.Flag("ignore-certificate-errors", true)) // RIP shittyproxy.go
 	options = append(options, chromedp.WindowSize(chrome.ResolutionX, chrome.ResolutionY))
+	
+	
+	
+	
+	
 
 	if chrome.ChromePath != "" {
 		options = append(options, chromedp.ExecPath(chrome.ChromePath))
@@ -420,6 +427,8 @@ func (chrome *Chrome) Screenshot(url *url.URL) (result *ScreenshotResult, err er
 // buildTasks builds the chromedp tasks slice
 func buildTasks(chrome *Chrome, url *url.URL, doNavigate bool, buf *[]byte, dom *string) chromedp.Tasks {
 	var actions chromedp.Tasks
+	// pass javascript code
+	var res *runtime.RemoteObject
 
 	if len(chrome.HeadersMap) > 0 {
 		actions = append(actions, network.Enable(), network.SetExtraHTTPHeaders(network.Headers(chrome.HeadersMap)))
@@ -427,6 +436,7 @@ func buildTasks(chrome *Chrome, url *url.URL, doNavigate bool, buf *[]byte, dom 
 
 	if doNavigate {
 		actions = append(actions, chromedp.Navigate(url.String()))
+		actions = append(actions, chromedp.Evaluate(chrome.JsCode, &res),)
 		if chrome.Delay > 0 {
 			actions = append(actions, chromedp.Sleep(time.Duration(chrome.Delay)*time.Second))
 		}
@@ -439,9 +449,7 @@ func buildTasks(chrome *Chrome, url *url.URL, doNavigate bool, buf *[]byte, dom 
 	// grab the dom
 	actions = append(actions, chromedp.OuterHTML(":root", dom, chromedp.ByQueryAll))
 	
-	var res string
-	// pass javascript code
-	actions = append(actions,chromedp.Evaluate(chrome.JsCode, &res),)
+	
 
 	// should we print as pdf?
 	if chrome.AsPDF {

--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -25,6 +25,7 @@ type Chrome struct {
 	ResolutionX int
 	ResolutionY int
 	UserAgent   string
+	JsCode      string
 	Timeout     int64
 	Delay       int
 	FullPage    bool
@@ -437,6 +438,9 @@ func buildTasks(chrome *Chrome, url *url.URL, doNavigate bool, buf *[]byte, dom 
 
 	// grab the dom
 	actions = append(actions, chromedp.OuterHTML(":root", dom, chromedp.ByQueryAll))
+	
+	// pass javascript code
+	actions = append(actions,chromedp.Evaluate(chrome.JsCode))
 
 	// should we print as pdf?
 	if chrome.AsPDF {

--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -439,8 +439,9 @@ func buildTasks(chrome *Chrome, url *url.URL, doNavigate bool, buf *[]byte, dom 
 	// grab the dom
 	actions = append(actions, chromedp.OuterHTML(":root", dom, chromedp.ByQueryAll))
 	
+	var res string
 	// pass javascript code
-	actions = append(actions,chromedp.Evaluate(chrome.JsCode))
+	actions = append(actions,chromedp.Evaluate(chrome.JsCode, &res),)
 
 	// should we print as pdf?
 	if chrome.AsPDF {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&chrm.ResolutionY, "resolution-y", "Y", 900, "screenshot resolution y")
 	rootCmd.PersistentFlags().IntVar(&chrm.Delay, "delay", 0, "delay in seconds between navigation and screenshot")
 	rootCmd.PersistentFlags().StringVar(&chrm.UserAgent, "user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36", "user agent string to use")
+	rootCmd.PersistentFlags().StringVar(&chrm.JsCode, "js", "console.log('your code is run')", "javascript code to excute")
 	rootCmd.PersistentFlags().StringSliceVar(&chrm.Headers, "header", []string{}, "Additional HTTP header to set. Supports multiple --header flags")
 	rootCmd.PersistentFlags().StringVarP(&options.ScreenshotPath, "screenshot-path", "P", "screenshots", "store path for screenshots (use . for pwd)")
 	rootCmd.PersistentFlags().BoolVarP(&chrm.FullPage, "fullpage", "F", false, "take fullpage screenshots")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/djallalzoldik/gowitness_js
+module github.com/sensepost/gowitness
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sensepost/gowitness
+module djallalzoldik/gowitness_js
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module djallalzoldik/gowitness_js
+module github.com/djallalzoldik/gowitness_js
 
 go 1.19
 


### PR DESCRIPTION
Hi , 

This feature will improve using gowitness, which can help you execute javascript code when screenshot, just with argument
 --js "here create you javascript code"

### example:

gowitness single "https://google.com" --js "console.log('your code is run')"

![jscode](https://user-images.githubusercontent.com/45321671/222978794-1f42832c-2e1e-483a-ab55-768c1f5729b3.png)


