### PR TITLE
Fix database file path location parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ screenshots/
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 .DS_Store
+.idea/

--- a/storage/db.go
+++ b/storage/db.go
@@ -65,14 +65,14 @@ func (db *Db) Get() (*gorm.DB, error) {
 	}
 
 	// Parse the DB URI.
-	parsedURI, dbLocation, err := parseDBLocation(db.Location)
+	location, dbLocation, err := parseDBLocation(db.Location)
 	if err != nil {
 		return nil, err
 	}
 
 	var conn *gorm.DB
 
-	switch parsedURI.Scheme {
+	switch location.Scheme {
 	case "sqlite":
 		conn, err = gorm.Open(sqlite.Open(dbLocation+"?cache=shared"), config)
 		if err != nil {

--- a/storage/db.go
+++ b/storage/db.go
@@ -2,9 +2,7 @@ package storage
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
-	"os"
 	"strings"
 
 	"gorm.io/driver/postgres"
@@ -44,11 +42,7 @@ func parseDBLocation(dbLocation string) (*url.URL, string, error) {
 		case location.Host != "" && location.Path == "":
 			return location, location.Host, nil
 		case location.Host == "" && location.Path == "":
-			cwd, err := os.Getwd()
-			if err != nil {
-				return nil, "", err
-			}
-			return location, fmt.Sprintf("%s/gowitness.sqlite3", cwd), nil
+			return location, "gowitness.sqlite3", nil
 		default:
 			return location, strings.TrimPrefix(dbLocation, "sqlite://"), nil
 		}
@@ -86,6 +80,11 @@ func (db *Db) Get() (*gorm.DB, error) {
 		}
 	case "postgres":
 		conn, err = gorm.Open(postgres.Open(db.Location), config)
+		if err != nil {
+			return nil, err
+		}
+	case "":
+		conn, err = gorm.Open(sqlite.Open(dbLocation+"?cache=shared"), config)
 		if err != nil {
 			return nil, err
 		}

--- a/storage/db.go
+++ b/storage/db.go
@@ -83,11 +83,6 @@ func (db *Db) Get() (*gorm.DB, error) {
 		if err != nil {
 			return nil, err
 		}
-	case "":
-		conn, err = gorm.Open(sqlite.Open(dbLocation+"?cache=shared"), config)
-		if err != nil {
-			return nil, err
-		}
 	default:
 		return nil, errors.New("unsupported database URI provided")
 	}

--- a/storage/db.go
+++ b/storage/db.go
@@ -35,7 +35,7 @@ func parseDBLocation(dbLocation string) (*url.URL, string, error) {
 	}
 
 	// Ensure the sqlite DB file path is correctly parsed via url.Parse
-	if location.Scheme != "postgres" {
+	if location.Scheme == "sqlite" {
 		switch {
 		case location.Host == "" && location.Path != "":
 			return location, location.Path, nil

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -41,7 +41,7 @@ func Test_parseDBLocation(t *testing.T) {
 			Path:   "/db",
 			User:   userInfo,
 		}, want1: "postgres://user:pass@host:5432/db", wantErr: false},
-		{name: "empty string test", args: args{dbLocation: ""}, want: &url.URL{}, want1: "gowitness.sqlite3", wantErr: false},
+		{name: "empty string test", args: args{dbLocation: ""}, want: &url.URL{}, want1: "", wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func Test_parseDBLocation(t *testing.T) {
+	userInfo := url.UserPassword("user", "pass")
+	type args struct {
+		dbLocation string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *url.URL
+		want1   string
+		wantErr bool
+	}{
+		{name: "default db location", args: args{dbLocation: "sqlite://gowitness.sqlite3"}, want: &url.URL{
+			Scheme: "sqlite",
+			Host:   "gowitness.sqlite3",
+		}, want1: "gowitness.sqlite3", wantErr: false},
+		{name: "absolute path db location", args: args{dbLocation: "sqlite:///tmp/testing/gowitness.sqlite3"}, want: &url.URL{
+			Scheme: "sqlite",
+			Path:   "/tmp/testing/gowitness.sqlite3",
+		}, want1: "/tmp/testing/gowitness.sqlite3", wantErr: false},
+		{name: "non default relative db location", args: args{dbLocation: "sqlite://bonkers.sqlite3"}, want: &url.URL{
+			Scheme: "sqlite",
+			Host:   "bonkers.sqlite3",
+		}, want1: "bonkers.sqlite3", wantErr: false},
+		{name: "empty incorrect dbLocation should revert to default path", args: args{dbLocation: "sqlite://"}, want: &url.URL{
+			Scheme: "sqlite",
+			Host:   "",
+			Path:   "",
+		}, want1: "gowitness.sqlite3", wantErr: false},
+		{name: "postgres db path", args: args{dbLocation: "postgres://user:pass@host:5432/db"}, want: &url.URL{
+			Scheme: "postgres",
+			Host:   "host:5432",
+			Path:   "/db",
+			User:   userInfo,
+		}, want1: "postgres://user:pass@host:5432/db", wantErr: false},
+		{name: "empty string test", args: args{dbLocation: ""}, want: &url.URL{}, want1: "gowitness.sqlite3", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := parseDBLocation(tt.args.dbLocation)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseDBLocation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseDBLocation() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("parseDBLocation() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I've encountered an issue in how absolute file paths are handled that are passed to the -D, --db-location flag. 

## Bug 🐛 

https://github.com/sensepost/gowitness/blob/master/storage/db.go#L52 is missing logic to appropriately handle absolute file paths, for example:
`'sqlite:///tmp/testing/gowitness.sqlite3'` returns an empty string after being parsed via url.Parse() when calling the .Host method. 

## Expected Functionality

Ability to specify absolute file paths to the -D, --db-location argument.

## Solution

I've implemented a helper function that fixes the issue and added some unit tests for verification.

## Passing Tests

Tested it with two trial runs that garnered the desired functionality.
Test cases are passing:
![image](https://github.com/sensepost/gowitness/assets/58376398/dd52bf5b-608c-478a-be1f-ac521b056499)


## Issue Representation Example Code

Here's an example demonstrating the issue: [GoPlayground](https://go.dev/play/p/rPFcQ63g7Vj)

Lemme know if this PR requires adjustments. 🍻 