### PR TITLE
(fix) MarshalJSON spells with one "l"

### DIFF
--- a/cmd/report_list.go
+++ b/cmd/report_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -53,7 +54,9 @@ $ gowitness report list --csv --sort`,
 		}
 
 		if options.ReportJSON {
-			outputJSON(&data)
+			if err := outputJSON(&data); err != nil {
+				log.Fatal().Err(err).Msg("failed to output json")
+			}
 			return
 		}
 
@@ -75,12 +78,16 @@ func init() {
 }
 
 // outputJSON prints the report in JSON format
-func outputJSON(d *[]storage.URL) {
+func outputJSON(d *[]storage.URL) error {
 
 	for _, l := range *d {
-		bytes, _ := l.MarshallJSON()
+		bytes, err := json.Marshal(l)
+		if err != nil {
+			return err
+		}
 		fmt.Print(string(bytes))
 	}
+	return nil
 }
 
 // outputCSV prints the report in CSV format

--- a/storage/models.go
+++ b/storage/models.go
@@ -60,8 +60,8 @@ func (url *URL) MarshallCSV() (res []string) {
 		url.Filename}
 }
 
-// MarshallJSON returns values as a slice
-func (url *URL) MarshallJSON() ([]byte, error) {
+// MarshalJSON returns JSON encoding of url. Implements json.Marshaler.
+func (url *URL) MarshalJSON() ([]byte, error) {
 	var tmp struct {
 		URL            string `json:"url"`
 		FinalURL       string `json:"final_url"`


### PR DESCRIPTION
This PR renames `MarshallJSON` to `MarshalJSON`. See the [`json.Marshaler`](https://pkg.go.dev/encoding/json#Marshaler) interface function `MarshalJSON`. Also, corrects the doc comment and adds error checking.