### PR TITLE
fix ipv6 address error

### DIFF
--- a/cmd/nmap.go
+++ b/cmd/nmap.go
@@ -178,7 +178,12 @@ func getNmapURLs() (urls []string, err error) {
 				}
 
 				// process the port successfully
-				urls = append(urls, buildURI(address.Addr, port.PortId)...)
+				if address.AddrType == "ipv4" {
+					urls = append(urls, buildURI(address.Addr, port.PortId)...)					
+				} else {
+					addr := fmt.Sprintf(`[%s]`, address.Addr)
+					urls = append(urls, buildURI(addr, port.PortId)...)			
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Processing of  IPv6 addresses from Nmap XML file was changed. IPv6 address should be in [] in URL to take screenshot.