### PR TITLE
Update nmap.go to use HTTPS as well instead of HTTP only

### DIFF
--- a/pkg/readers/nmap.go
+++ b/pkg/readers/nmap.go
@@ -134,7 +134,7 @@ func (nr *NmapReader) urlsFor(target string, port int) []string {
 	}
 
 	if !nr.Options.NoHTTPS {
-		urls = append(urls, fmt.Sprintf("http://%s:%d", target, port))
+		urls = append(urls, fmt.Sprintf("https://%s:%d", target, port))
 	}
 
 	return urls


### PR DESCRIPTION
Noticed that the reader always prepends "http", even if HTTPS is enabled. Changed the code to prepend "https" whenever necessary.