### PR TITLE
Fix loading script from file and evaluate as devtools for chromedp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ screenshots/
 .glide/
 .DS_Store
 .idea/
+
+tld-cache.txt

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/joeguo/tldextract"
+	"github.com/sensepost/gowitness/internal/ascii"
+	"github.com/sensepost/gowitness/pkg/database"
+	"github.com/sensepost/gowitness/pkg/log"
+	"github.com/spf13/cobra"
+)
+
+var pluginCmd = &cobra.Command{
+	Use:   "plugin",
+	Short: "Use gowitness plugins",
+	Long:  ascii.LogoHelp(`Use gowitness plugins`),
+}
+
+type NetworkLogResult struct {
+	URL string
+	Log string
+}
+
+func GenerateParentPaths(rawURL string) ([]string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the path without query/fragment
+	p := parsed.Path
+	// Ensure it ends without a slash for consistent splitting
+	p = strings.TrimSuffix(p, "/")
+
+	segments := strings.Split(p, "/")
+	var results []string
+
+	// Build progressively shorter paths (but not the file itself)
+	for i := len(segments) - 1; i > 0; i-- {
+		joined := strings.Join(segments[:i], "/") + "/"
+		u := *parsed
+		u.Path = joined
+		results = append(results, strings.Split(u.String(), "?")[0])
+	}
+
+	return results, nil
+}
+
+var pathsCmd = &cobra.Command{
+	Use:   "paths",
+	Short: "Extract unique in scope paths for all visited hosts",
+	Long:  ascii.LogoHelp(`Take all the visited hosts, loop through loaded resources, pick the ones in scope, enumerate over the possible paths`),
+	Run: func(cmd *cobra.Command, args []string) {
+		c, err := database.Connection(opts.Writer.DbURI, true, false)
+		if err != nil {
+			log.Fatal("failed to connect to database", "error", err)
+		}
+		var result []NetworkLogResult
+		c.Raw("SELECT DISTINCT r.url as URL, nl.url as Log FROM results r JOIN network_logs nl ON r.id = nl.result_id").Scan(&result)
+		tldExtractor, _ := tldextract.New("tld-cache.txt", false)
+		tldCache := map[string]string{}
+		for _, r := range result {
+			// Extract the registered domain (eTLD+1)
+			root, ok := tldCache[r.URL]
+			if !ok {
+				e := tldExtractor.Extract(r.URL)
+				tldCache[r.URL] = e.Root + e.Tld
+			}
+			l := tldExtractor.Extract(r.Log)
+			if l.Root+l.Tld != root {
+				continue
+			}
+			p, _ := GenerateParentPaths(r.Log)
+			for _, pp := range p {
+				fmt.Println(pp)
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pluginCmd)
+	pluginCmd.PersistentFlags().StringVar(&opts.Writer.DbURI, "write-db-uri", "sqlite://gowitness.sqlite3", "The database URI to use. Supports SQLite, Postgres, and MySQL (e.g., postgres://user:pass@host:port/db)")
+	pluginCmd.AddCommand(pathsCmd)
+
+}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -54,20 +54,6 @@ flags.`)),
 		logger := slog.New(log.Logger)
 
 		// Configure the driver
-		switch opts.Scan.Driver {
-		case "gorod":
-			scanDriver, err = driver.NewGorod(logger, *opts)
-			if err != nil {
-				return err
-			}
-		case "chromedp":
-			scanDriver, err = driver.NewChromedp(logger, *opts)
-			if err != nil {
-				return err
-			}
-		default:
-			return errors.New("invalid scan driver chosen")
-		}
 
 		log.Debug("scanning driver started", "driver", opts.Scan.Driver)
 
@@ -118,10 +104,27 @@ flags.`)),
 		}
 
 		// Get the runner up. Basically, all of the subcommands will use this.
-		scanRunner, err = runner.NewRunner(logger, scanDriver, *opts, scanWriters)
+		scanRunner, err = runner.NewRunner(logger, opts, scanWriters)
 		if err != nil {
 			return err
 		}
+
+		switch opts.Scan.Driver {
+		case "gorod":
+			scanDriver, err = driver.NewGorod(logger, *opts)
+			if err != nil {
+				return err
+			}
+		case "chromedp":
+			scanDriver, err = driver.NewChromedp(logger, *opts)
+			if err != nil {
+				return err
+			}
+		default:
+			return errors.New("invalid scan driver chosen")
+		}
+
+		scanRunner.Driver = scanDriver
 
 		return nil
 		// TODO: maybe add https://github.com/projectdiscovery/networkpolicy support?

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.0
 	github.com/go-chi/cors v1.2.1
 	github.com/go-rod/rod v0.116.2
+	github.com/joeguo/tldextract v0.0.0-20220507100122-d83daa6adef8
 	github.com/lair-framework/go-nmap v0.0.0-20191202052157-3507e0b03523
 	github.com/projectdiscovery/wappalyzergo v0.2.7
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/joeguo/tldextract v0.0.0-20220507100122-d83daa6adef8 h1:Ig0ESdy6JtHI17vsb7L+UlUFpoZctKfvBZplcILeL6g=
+github.com/joeguo/tldextract v0.0.0-20220507100122-d83daa6adef8/go.mod h1:oGfutRjaB95239mjFVwofaOPTwuS3vb71ZLIGCEb36g=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -23,7 +23,7 @@ type Result struct {
 	ResponseReason        string    `json:"response_reason"`
 	Protocol              string    `json:"protocol"`
 	ContentLength         int64     `json:"content_length"`
-	HTML                  string    `json:"html" gorm:"index"`
+	HTML                  string    `json:"html"`
 	Title                 string    `json:"title" gorm:"index"`
 	PerceptionHash        string    `json:"perception_hash" gorm:"index"`
 	PerceptionHashGroupId uint      `json:"perception_hash_group_id" gorm:"index"`

--- a/pkg/runner/drivers/chromedp.go
+++ b/pkg/runner/drivers/chromedp.go
@@ -351,9 +351,12 @@ func (run *Chromedp) Witness(target string, thisRunner *runner.Runner) (*models.
 
 	// run any javascript we have
 	if run.options.Scan.JavaScript != "" {
-		if err := chromedp.Run(navigationCtx, chromedp.Evaluate(run.options.Scan.JavaScript, nil)); err != nil {
+		// maybe can be added to outputs?
+		var jsResult []byte
+		if err := chromedp.Run(navigationCtx, chromedp.EvaluateAsDevTools(run.options.Scan.JavaScript, &jsResult)); err != nil {
 			return nil, fmt.Errorf("failed to evaluate user-provided javascript: %w", err)
 		}
+		logger.Debug("ran user-provided javascript", "result", string(jsResult))
 	}
 
 	// get cookies

--- a/pkg/runner/drivers/chromedp.go
+++ b/pkg/runner/drivers/chromedp.go
@@ -357,6 +357,9 @@ func (run *Chromedp) Witness(target string, thisRunner *runner.Runner) (*models.
 			return nil, fmt.Errorf("failed to evaluate user-provided javascript: %w", err)
 		}
 		logger.Debug("ran user-provided javascript", "result", string(jsResult))
+		if run.options.Scan.Delay > 0 {
+			time.Sleep(time.Duration(run.options.Scan.Delay) * time.Second)
+		}
 	}
 
 	// get cookies

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -20,7 +20,7 @@ type Runner struct {
 	Wappalyzer *wappalyzer.Wappalyze
 
 	// options for the Runner to consider
-	options Options
+	options *Options
 	// writers are the result writers to use
 	writers []writers.Writer
 	// log handler
@@ -37,7 +37,7 @@ type Runner struct {
 
 // New gets a new Runner ready for probing.
 // It's up to the caller to call Close() on the runner
-func NewRunner(logger *slog.Logger, driver Driver, opts Options, writers []writers.Writer) (*Runner, error) {
+func NewRunner(logger *slog.Logger, opts *Options, writers []writers.Writer) (*Runner, error) {
 	if !opts.Scan.ScreenshotSkipSave {
 		screenshotPath, err := islazy.CreateDir(opts.Scan.ScreenshotPath)
 		if err != nil {
@@ -74,7 +74,6 @@ func NewRunner(logger *slog.Logger, driver Driver, opts Options, writers []write
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Runner{
-		Driver:     driver,
 		Wappalyzer: wap,
 		options:    opts,
 		writers:    writers,

--- a/web/api/submit.go
+++ b/web/api/submit.go
@@ -81,18 +81,20 @@ func (h *ApiHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 
 	logger := slog.New(log.Logger)
 
+	runner, err := runner.NewRunner(logger, options, []writers.Writer{writer})
+	if err != nil {
+		log.Error("error starting runner", "err", err)
+		http.Error(w, "Error starting runner", http.StatusInternalServerError)
+		return
+	}
+
 	driver, err := driver.NewChromedp(logger, *options)
 	if err != nil {
 		http.Error(w, "Error sarting driver", http.StatusInternalServerError)
 		return
 	}
 
-	runner, err := runner.NewRunner(logger, driver, *options, []writers.Writer{writer})
-	if err != nil {
-		log.Error("error starting runner", "err", err)
-		http.Error(w, "Error starting runner", http.StatusInternalServerError)
-		return
-	}
+	runner.Driver = driver
 
 	// have everything we need! start ther runner goroutine
 	go dispatchRunner(runner, request.URLs)

--- a/web/api/submit_single.go
+++ b/web/api/submit_single.go
@@ -73,18 +73,20 @@ func (h *ApiHandler) SubmitSingleHandler(w http.ResponseWriter, r *http.Request)
 
 	logger := slog.New(log.Logger)
 
+	runner, err := runner.NewRunner(logger, options, []writers.Writer{writer})
+	if err != nil {
+		log.Error("error starting runner", "err", err)
+		http.Error(w, "Error starting runner", http.StatusInternalServerError)
+		return
+	}
+
 	driver, err := driver.NewChromedp(logger, *options)
 	if err != nil {
 		http.Error(w, "Error sarting driver", http.StatusInternalServerError)
 		return
 	}
 
-	runner, err := runner.NewRunner(logger, driver, *options, []writers.Writer{writer})
-	if err != nil {
-		log.Error("error starting runner", "err", err)
-		http.Error(w, "Error starting runner", http.StatusInternalServerError)
-		return
-	}
+	runner.Driver = driver
 
 	go func() {
 		runner.Targets <- request.URL


### PR DESCRIPTION
Hi there!

First of all, love the tool and are an avid user. 

I was trying to work with the `--javascript-file` and I noticed it would just not run for me, it seems like the way `opts` were handled the version copied to the runner was resetting the `Scan.JavaScript` to `""`, leaving it with nothing to run.

Additionally I noticed that when working with more complex js I would get a lot of errors, however using `EvaluateAsDevTools` instead of `Evaluate` worked like a charm in chromedp.

Another good addition could be to add the return of the js being executed to the outputs. Also I am not sure if the same problem for `gorod` was present, might want to investigate.