### PR TITLE
Ignore error if the build directory doesn't exist yet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ default: clean test frontend api-doc build integrity
 
 # Clean up build artifacts
 clean:
-	find $(BIN_DIR) -type f -name 'gowitness-*' -delete
+	find $(BIN_DIR) -type f -name 'gowitness-*' -delete || true
 	go clean -x
 
 # Build frontend


### PR DESCRIPTION
The make command fails after a fresh clone, since the "build" directory doesn't exist.

Adding "|| true" after find ignores this error and allows the process to continue.