### PR TITLE
Solved Issue for  Query Parameters When Reading URLs from File

### DIFF
--- a/pkg/readers/file.go
+++ b/pkg/readers/file.go
@@ -166,6 +166,7 @@ func (fr *FileReader) urlsFor(candidate string, ports []int) []string {
 				Scheme: scheme,
 				Host:   host,
 				Path:   parsedURL.Path,
+				RawQuery: parsedURL.RawQuery,
 			}
 
 			urls = append(urls, fullURL.String())


### PR DESCRIPTION
### 🔧 Fix: **Parameter-Based Screenshot Handling for File Input**

**When feeding URLs through a file using:**
```
gowitness scan file -f test.txt
```
Any query parameters (?id=123&name=test) were getting stripped.
 
_Using --url directly worked fine, but reading from file dropped everything after ? — neutering  recon and breaking coverage on dynamic routes or param-based content._

**Inside test.txt**
```
http://example.com/path?query=123&name=test
https://test-site.com/resource?id=42
```
**Before: **
Tool only takes screenshot of 
```
http://example.com:80/path

https://test-site.com/resource
```
![before1](https://github.com/user-attachments/assets/63190bee-ca1a-4763-9a0d-f519dfee2b48)

**After** : Query parameters are fully preserved, screenshots now match the actual request paths

Tool  takes screenshot of full url 
```
http://example.com/path?query=123&name=test

https://test-site.com/resource?id=42
```
![after1](https://github.com/user-attachments/assets/d5feb0da-bef5-4a75-bb4e-043b58d7ee18)

### In short 

**This fix ensures that URLs with query parameters are processed correctly, which is critical for scanning web applications that rely on query parameters for functionality.**