### PR TITLE
Fix "error enabling network tracking: context deadline exceeded" error message

### DIFF
--- a/pkg/runner/drivers/chromedp.go
+++ b/pkg/runner/drivers/chromedp.go
@@ -82,6 +82,8 @@ func getChromedpAllocator(opts runner.Options) (*browserInstance, error) {
 			chromedp.Flag("disable-renderer-backgrounding", true),
 			chromedp.Flag("deny-permission-prompts", true),
 			chromedp.Flag("explicitly-allowed-ports", restrictedPorts()),
+			chromedp.Flag("no-sandbox", true),
+			chromedp.Flag("disable-gpu", true),
 			chromedp.WindowSize(opts.Chrome.WindowX, opts.Chrome.WindowY),
 			chromedp.UserDataDir(userData),
 		)


### PR DESCRIPTION
Hello,

After executing the `gowitness scan single -u https://example.com/ --timeout 10 --write-csv --log-scan-errors` command, I observed the following error message:
`2025/09/24 10:46:56 ERRO failed to witness target target=https://example.com/ err="error enabling network tracking: context deadline exceeded"`

I compiled the code myself from GitHub and also tried the one from the official Kali Linux package repository, to no avail.

I then added the following flags to the Chrome context to fix the issue:
- no-sandbox
- disable-gpu