### PR TITLE
logic for nessus reader and IPv6

### DIFF
--- a/pkg/readers/nessus.go
+++ b/pkg/readers/nessus.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"net"
 
 	"github.com/sensepost/gowitness/internal/islazy"
 )
@@ -134,15 +135,21 @@ func (nr *NessusReader) Read(ch chan<- string) error {
 func (nr *NessusReader) urlsFor(target string, ports []int) []string {
 	var urls []string
 
+	ip := net.ParseIP(target)
+	
+	host := target
+	if ip != nil && ip.To4() == nil {
+		host = fmt.Sprintf("[%s]", target)
+	}
+	
 	for _, port := range ports {
 		if !nr.Options.NoHTTP {
-			urls = append(urls, fmt.Sprintf("http://%s:%d", target, port))
+			urls = append(urls, fmt.Sprintf("http://%s:%d", host, port))
 		}
-
 		if !nr.Options.NoHTTPS {
-			urls = append(urls, fmt.Sprintf("https://%s:%d", target, port))
+			urls = append(urls, fmt.Sprintf("https://%s:%d", host, port))
 		}
 	}
-
+	
 	return urls
 }


### PR DESCRIPTION
Nmap and the file readers handle IPv6. The Nessus one doesn't. Added logic to check if its IPv6, if it is, add the `[` and `]`. Worked on my Nessus file without issue.