### PR TITLE
Refactor Gallery component to use navigate instead of Link

### DIFF
--- a/web/ui/src/pages/gallery/Gallery.tsx
+++ b/web/ui/src/pages/gallery/Gallery.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { useEffect, useMemo, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { WideSkeleton } from "@/components/loading";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -30,6 +30,7 @@ const GalleryPage = () => {
   const [loading, setLoading] = useState(true);
 
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
   // pagination
   const page = parseInt(searchParams.get("page") || "1");
   const limit = parseInt(searchParams.get("limit") || "24");
@@ -168,7 +169,7 @@ const GalleryPage = () => {
     const rawDate = format(probedDate, "PPpp"); // Formats the date in a readable format
 
     return (
-      <Link to={`/screenshot/${screenshot.id}`} key={screenshot.id}>
+      <div key={screenshot.id}>
         <Card className="group overflow-hidden transition-all hover:shadow-lg flex flex-col h-full">
           <CardContent className="p-0 relative flex-grow">
             {screenshot.failed ? (
@@ -182,7 +183,15 @@ const GalleryPage = () => {
                   : api.endpoints.screenshot.path + "/" + screenshot.file_name}
                 alt={screenshot.url}
                 loading="lazy"
-                className="w-full h-48 object-cover transition-all duration-300 filter group-hover:scale-105"
+                className="w-full h-48 object-cover transition-all duration-300 filter group-hover:scale-105 cursor-pointer"
+                onClick={() => navigate(`/screenshot/${screenshot.id}`)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    navigate(`/screenshot/${screenshot.id}`);
+                  }
+                }}
+                tabIndex={0}
+                role="link"
               />
             )}
             <div className="absolute top-2 right-2">
@@ -190,71 +199,78 @@ const GalleryPage = () => {
                 {screenshot.response_code}
               </Badge>
             </div>
-            <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
-              <ExternalLinkIcon className="text-white drop-shadow-lg" />
-            </div>
-          </CardContent>
+              <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <ExternalLinkIcon className="text-white drop-shadow-lg" />
+              </div>
+            </CardContent>
 
-          <CardFooter className="p-2 flex flex-col items-start">
-            <div className="w-full mb-2">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="w-full truncate text-sm font-medium">
-                      {screenshot.title || "Untitled"}
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{screenshot.title || "Untitled"}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <div className="w-full truncate text-xs text-muted-foreground mt-1">
-                {screenshot.url}
+            <CardFooter className="p-2 flex flex-col items-start">
+              <div className="w-full mb-2">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="w-full truncate text-sm font-medium">
+                        {screenshot.title || "Untitled"}
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>{screenshot.title || "Untitled"}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <a
+                  href={screenshot.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full inline-flex items-center gap-1 truncate text-xs text-muted-foreground mt-1 hover:underline hover:text-foreground underline-offset-2"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <span className="truncate">{screenshot.url}</span>
+                  <ExternalLinkIcon className="w-3 h-3 text-muted-foreground transition-colors" aria-hidden="true" />
+                </a>
               </div>
-            </div>
-            <div className="w-full flex items-center justify-between mt-2">
-              <TooltipProvider delayDuration={0}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="flex items-center space-x-1 text-xs text-muted-foreground">
-                      <ClockIcon className="w-3 h-3" />
-                      <span className="text-nowrap">{timeAgo}</span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="text-xs">
-                    <p>{rawDate}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <div className="flex flex-wrap justify-end gap-1">
-                {screenshot.technologies?.map(tech => {
-                  const iconUrl = getIconUrl(tech, wappalyzer);
-                  return iconUrl ? (
-                    <TooltipProvider key={tech} delayDuration={0}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="w-6 h-6 flex items-center justify-center">
-                            <img
-                              src={iconUrl}
-                              alt={tech}
-                              loading="lazy"
-                              className="w-5 h-5 object-contain"
-                            />
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>{tech}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  ) : null;
-                })}
+              <div className="w-full flex items-center justify-between mt-2">
+                <TooltipProvider delayDuration={0}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="flex items-center space-x-1 text-xs text-muted-foreground">
+                        <ClockIcon className="w-3 h-3" />
+                        <span className="text-nowrap">{timeAgo}</span>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="text-xs">
+                      <p>{rawDate}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <div className="flex flex-wrap justify-end gap-1">
+                  {screenshot.technologies?.map(tech => {
+                    const iconUrl = getIconUrl(tech, wappalyzer);
+                    return iconUrl ? (
+                      <TooltipProvider key={tech} delayDuration={0}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="w-6 h-6 flex items-center justify-center">
+                              <img
+                                src={iconUrl}
+                                alt={tech}
+                                loading="lazy"
+                                className="w-5 h-5 object-contain"
+                              />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>{tech}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    ) : null;
+                  })}
+                </div>
               </div>
-            </div>
-          </CardFooter>
+            </CardFooter>
         </Card>
-      </Link>
+      </div>
     );
   };
 


### PR DESCRIPTION
**Summary**
- Replace whole-card `Link` navigation with `useNavigate` and local click/keyboard handlers.
- Restrict “open screenshot details” navigation to the thumbnail image only.
- Convert the URL text into an external link that opens in a new tab, with a small external-link icon and subtle hover feedback.
- Prevent link clicks from bubbling and accidentally triggering the details navigation.

**Motivation**
- Reduce accidental navigation to `screenshot/:id` when interacting near the URL text.
- Provide a clear, direct way to open the target site from the gallery list without visiting the details page first.
- Improve affordance and clarity with minimal visual noise, keeping the UI restrained and consistent.

**Key Changes**
- Use programmatic navigation via `useNavigate`: `web/ui/src/pages/gallery/Gallery.tsx:4`
- Remove the outer container’s click/keyboard handling; make the thumbnail image the only trigger:
  - Removed outer-container navigation: `web/ui/src/pages/gallery/Gallery.tsx:171–182`
  - Added click/keyboard handlers on the `<img>` (with `tabIndex={0}` and `role="link"`): `web/ui/src/pages/gallery/Gallery.tsx:190–199`
- Turn URL text into an external link with icon and hover styling:
  - `<a href={screenshot.url} target="_blank" rel="noopener noreferrer">` plus `ExternalLinkIcon` and `hover:underline` / `hover:text-foreground`: `web/ui/src/pages/gallery/Gallery.tsx:223–231`
  - Stop event propagation on the link to avoid triggering the thumbnail navigation.
- Preserve existing badges, tooltips, technologies, timestamps, and layout.

**UX & Accessibility**
- Thumbnail click or Enter/Space now navigates to `screenshot/:id`.
- URL link opens the target site in a new tab; hover underline and color shift make the link more discoverable, and a small external-link icon reinforces intent.
- The rest of the card no longer triggers navigation, reducing misclicks.
- The thumbnail remains keyboard accessible, while the URL is a native link for assistive technologies.