### PR TITLE
Implemented Bookmarks Feature

### DIFF
--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -28,6 +28,7 @@ type Result struct {
 	PerceptionHash        string    `json:"perception_hash" gorm:"index"`
 	PerceptionHashGroupId uint      `json:"perception_hash_group_id" gorm:"index"`
 	Screenshot            string    `json:"screenshot"`
+	Bookmarked            bool      `json:"bookmarked"`
 
 	// Name of the screenshot file
 	Filename string `json:"file_name"`

--- a/web/api/bookmark.go
+++ b/web/api/bookmark.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/sensepost/gowitness/pkg/log"
+)
+
+type bookmarkRequest struct {
+	ID int `json:"id"`
+}
+
+// BookmarkHandler marks a result as bookmarked.
+//
+//	@Summary		Bookmark results
+//	@Description	Marks a given result as bookmarked, writing results to the database.
+//	@Tags			Results
+//	@Accept			json
+//	@Produce		json
+//	@Param			query	body	bookmarkRequest	true	"The bookmark request object"
+//	@Success		200		{string}	string			"ok"
+//	@Router			/results/bookmark [post]
+func (h *ApiHandler) BookmarkHandler(w http.ResponseWriter, r *http.Request) {
+	var request bookmarkRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		log.Error("failed to read json request", "err", err)
+		http.Error(w, "Error reading JSON request", http.StatusInternalServerError)
+		return
+	}
+
+	log.Info("bookmarking id", "id", request.ID)
+
+	if err := h.DB.Update("bookmark", true).Where("id = ?", request.ID).Error; err != nil {
+		log.Error("failed to bookmark result", "err", err)
+		return
+	}
+
+	response := `ok`
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, "Error creating JSON response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(jsonData)
+}

--- a/web/api/bookmark.go
+++ b/web/api/bookmark.go
@@ -11,15 +11,15 @@ type bookmarkRequest struct {
 	ID int `json:"id"`
 }
 
-// BookmarkHandler marks a result as bookmarked.
+// BookmarkHandler inverts the state of a bookmark
 //
-//	@Summary		Bookmark results
-//	@Description	Marks a given result as bookmarked, writing results to the database.
+//	@Summary		Bookmark/Unbookmarks result
+//	@Description	Inverts the bookmark status of a result, writing results to the database.
 //	@Tags			Results
 //	@Accept			json
 //	@Produce		json
 //	@Param			query	body	bookmarkRequest	true	"The bookmark request object"
-//	@Success		200		{string}	string			"ok"
+//	@Success		200		{string}	string			"bookmarked"
 //	@Router			/results/bookmark [post]
 func (h *ApiHandler) BookmarkHandler(w http.ResponseWriter, r *http.Request) {
 	var request bookmarkRequest
@@ -29,14 +29,29 @@ func (h *ApiHandler) BookmarkHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Info("bookmarking id", "id", request.ID)
-
-	if err := h.DB.Update("bookmark", true).Where("id = ?", request.ID).Error; err != nil {
-		log.Error("failed to bookmark result", "err", err)
+	var bookmarked bool
+	var err error
+	bookmarkResult := h.DB.Select("bookmarked").Where("id = ?", request.ID).First(&bookmarked)
+	if bookmarkResult.Error != nil {
+		log.Error("failed to get bookmark status", "err", bookmarkResult.Error)
+		http.Error(w, "Error getting result bookmark value", http.StatusInternalServerError)
 		return
 	}
 
-	response := `ok`
+	log.Info("inverting bookmark id", "id", request.ID)
+	if err := h.DB.Update("bookmark", !bookmarked).Where("id = ?", request.ID).Error; err != nil {
+		log.Error("failed to update result bookmark", "err", err)
+		http.Error(w, "Error updating result bookmark value", http.StatusInternalServerError)
+		return
+	}
+
+	var response string
+	if bookmarked {
+		response = `removed bookmark`
+	} else {
+		response = `bookmarked`
+	}
+
 	jsonData, err := json.Marshal(response)
 	if err != nil {
 		http.Error(w, "Error creating JSON response", http.StatusInternalServerError)

--- a/web/api/gallery.go
+++ b/web/api/gallery.go
@@ -158,6 +158,7 @@ func (h *ApiHandler) GalleryHandler(w http.ResponseWriter, r *http.Request) {
 			Screenshot:   result.Screenshot,
 			Failed:       result.Failed,
 			Technologies: technologies,
+			Bookmarked:   result.Bookmarked,
 		})
 	}
 

--- a/web/api/gallery.go
+++ b/web/api/gallery.go
@@ -28,6 +28,7 @@ type galleryContent struct {
 	Screenshot   string    `json:"screenshot"`
 	Failed       bool      `json:"failed"`
 	Technologies []string  `json:"technologies"`
+	Bookmarked   bool      `json:"bookmarked"`
 }
 
 // GalleryHandler gets a paginated gallery
@@ -43,6 +44,7 @@ type galleryContent struct {
 //	@Param			status			query		string	false	"A comma seperated list of HTTP status codes to filter by."
 //	@Param			perception		query		boolean	false	"Order the results by perception hash."
 //	@Param			failed			query		boolean	false	"Include failed screenshots in the results."
+//	@Param			bookmarked		query		boolean	false	"Only return bookmarked items"
 //	@Success		200				{object}	galleryResponse
 //	@Router			/results/gallery [get]
 func (h *ApiHandler) GalleryHandler(w http.ResponseWriter, r *http.Request) {
@@ -98,6 +100,13 @@ func (h *ApiHandler) GalleryHandler(w http.ResponseWriter, r *http.Request) {
 		showFailed = true
 	}
 
+	// bookmarked filtering
+	var bookmarked bool
+	bookmarked, err = strconv.ParseBool(r.URL.Query().Get("bookmarked"))
+	if err != nil {
+		bookmarked = false
+	}
+
 	// query the db
 	var queryResults []*models.Result
 	query := h.DB.Model(&models.Result{}).Limit(results.Limit).
@@ -119,6 +128,10 @@ func (h *ApiHandler) GalleryHandler(w http.ResponseWriter, r *http.Request) {
 
 	if !showFailed {
 		query.Where("failed = ?", showFailed)
+	}
+
+	if bookmarked {
+		query.Where("bookmarked = ?", bookmarked)
 	}
 
 	// run the query

--- a/web/api/list.go
+++ b/web/api/list.go
@@ -18,6 +18,7 @@ type listResponse struct {
 	Protocol       string `json:"protocol"`
 	ContentLength  int64  `json:"content_length"`
 	Title          string `json:"title"`
+	Bookmarked     bool   `json:"bookmarked"`
 
 	// Failed flag set if the result should be considered failed
 	Failed       bool   `json:"failed"`

--- a/web/api/search.go
+++ b/web/api/search.go
@@ -29,12 +29,13 @@ type searchResult struct {
 	FailedReason   string   `json:"failed_reason"`
 	Filename       string   `json:"file_name"`
 	Screenshot     string   `json:"screenshot"`
+	Bookmarked     bool     `json:"bookmarked"`
 	MatchedFields  []string `json:"matched_fields"`
 }
 
 // searchOperators are the operators we support. everything else is
 // "free text"
-var searchOperators = []string{"title", "body", "tech", "header", "p"}
+var searchOperators = []string{"title", "body", "tech", "header", "p", "bookmarked"}
 
 // SearchHandler handles search
 //

--- a/web/server.go
+++ b/web/server.go
@@ -79,6 +79,7 @@ func (s *Server) Run() {
 		r.Get("/results/gallery", apih.GalleryHandler)
 		r.Get("/results/list", apih.ListHandler)
 		r.Get("/results/detail/{id}", apih.DetailHandler)
+		r.Post("/results/bookmark", apih.BookmarkHandler)
 		r.Post("/results/delete", apih.DeleteResultHandler)
 		r.Get("/results/technology", apih.TechnologyListHandler)
 	})

--- a/web/ui/src/lib/api/api.ts
+++ b/web/ui/src/lib/api/api.ts
@@ -47,6 +47,10 @@ const endpoints = {
     path: `/search`,
     returnas: {} as searchresult
   },
+  bookmark: {
+    path: `/results/bookmark`,
+    returnas: "" as string
+  },
   delete: {
     path: `/results/delete`,
     returnas: "" as string

--- a/web/ui/src/lib/api/bookmark.ts
+++ b/web/ui/src/lib/api/bookmark.ts
@@ -1,7 +1,7 @@
 import { toast } from "@/hooks/use-toast";
 import * as api from "@/lib/api/api";
 
-const bookmarkResult = async (id: string): Promise<boolean> => {
+const bookmarkResult = async (id: number): Promise<boolean> => {
     try {
         await api.post('bookmark', { id });
     } catch (error) {
@@ -14,7 +14,7 @@ const bookmarkResult = async (id: string): Promise<boolean> => {
         return false;
     }
     toast({
-        description: "Result bookmark inverted"
+        description: "Result bookmark updated"
     });
 
     return true;

--- a/web/ui/src/lib/api/bookmark.ts
+++ b/web/ui/src/lib/api/bookmark.ts
@@ -1,0 +1,23 @@
+import { toast } from "@/hooks/use-toast";
+import * as api from "@/lib/api/api";
+
+const bookmarkResult = async (id: string): Promise<boolean> => {
+    try {
+        await api.post('bookmark', { id });
+    } catch (error) {
+        toast({
+            title: "API Error",
+            variant: "destructive",
+            description: `Failed to bookmark result: ${error}`
+        });
+
+        return false;
+    }
+    toast({
+        description: "Result bookmark inverted"
+    });
+
+    return true;
+}
+
+export { bookmarkResult };

--- a/web/ui/src/lib/api/types.ts
+++ b/web/ui/src/lib/api/types.ts
@@ -36,6 +36,7 @@ type galleryResult = {
   screenshot: string;
   failed: boolean;
   technologies: string[];
+  bookmarked: boolean;
 };
 
 // list
@@ -48,6 +49,7 @@ type list = {
   protocol: string;
   content_length: number;
   title: string;
+  bookmarked: boolean;
   failed: boolean;
   failed_reason: string;
 };
@@ -136,6 +138,7 @@ interface detail {
   html: string;
   title: string;
   perception_hash: string;
+  bookmarked: boolean;
   file_name: string;
   is_pdf: boolean;
   failed: boolean;
@@ -159,6 +162,7 @@ interface searchresult {
   matched_fields: string[];
   file_name: string;
   screenshot: string;
+  bookmarked: boolean;
 }
 
 interface technologylist {

--- a/web/ui/src/pages/detail/Detail.tsx
+++ b/web/ui/src/pages/detail/Detail.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ExternalLink, ChevronLeft, ChevronRight, Code, ClockIcon, Trash2Icon, DownloadIcon, ImagesIcon, ZoomInIcon, CopyIcon } from 'lucide-react';
+import { BookmarkIcon, BookmarkFilledIcon } from "@radix-ui/react-icons";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, } from "@/components/ui/dialog";
 import { WideSkeleton } from '@/components/loading';
 import { Form, Link, useNavigate, useParams } from 'react-router-dom';
@@ -14,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { copyToClipboard, getIconUrl, getStatusColor } from '@/lib/common';
 import * as api from "@/lib/api/api";
 import * as apitypes from "@/lib/api/types";
+import { bookmarkResult } from "@/lib/api/bookmark";
 import { getData } from './data';
 
 
@@ -93,6 +95,21 @@ const ScreenshotDetailPage = () => {
     }
   };
 
+  const handleBookmarkClick = async () => {
+    const bookmarkUpdated = await bookmarkResult(currentId)
+    if (bookmarkUpdated) {
+      setDetail(prevDetail => {
+         if (!prevDetail) {
+           return prevDetail;
+         }
+         return {
+           ...prevDetail,
+           bookmarked: !prevDetail.bookmarked
+         };
+       });
+    }
+  }
+
   if (loading) return <WideSkeleton />;
   if (!detail) return;
 
@@ -132,6 +149,23 @@ const ScreenshotDetailPage = () => {
               </TooltipTrigger>
               <TooltipContent>
                 <p>Find visually similar screenshots</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleBookmarkClick}
+                >
+                  {detail.bookmarked ? <BookmarkFilledIcon className="mr-2 h-4 w-4" />: <BookmarkIcon className="mr-2 h-4 w-4" />}
+                  Bookmark
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Bookmark result</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/web/ui/src/pages/gallery/Gallery.tsx
+++ b/web/ui/src/pages/gallery/Gallery.tsx
@@ -217,8 +217,8 @@ const GalleryPage = () => {
           </CardContent>
 
           <CardFooter className="p-2 flex flex-col items-start">
-            <div className="flex flex-row" style={{ width: "100%" }}>
-              <div className="w-full mb-2">
+            <div className="flex flex-row items-start gap-2 w-full">
+              <div className="flex-1 min-w-0 mb-2">
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -235,7 +235,7 @@ const GalleryPage = () => {
                   {screenshot.url}
                 </div>
               </div>
-              <div style={{ marginLeft: "auto"}}
+              <div className="flex-shrink-0"
                 onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/web/ui/src/pages/gallery/Gallery.tsx
+++ b/web/ui/src/pages/gallery/Gallery.tsx
@@ -235,14 +235,14 @@ const GalleryPage = () => {
                   {screenshot.url}
                 </div>
               </div>
-              <div style={{ marginLeft: "auto"}} 
+              <div style={{ marginLeft: "auto"}}
                 onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
                     handleBookmarkClick(screenshot.id);
                   }}
               >
-                {screenshot.bookmarked ? <BookmarkFilledIcon style={{ width: "24px", height: "24px"}}/>: <BookmarkIcon style={{ width: "24px", height: "24px"}}/>}
+                {screenshot.bookmarked ? <BookmarkFilledIcon className="w-6 h-6"/>: <BookmarkIcon className="w-6 h-6"/>}
               </div>
             </div>
             <div className="w-full flex items-center justify-between mt-2">
@@ -368,7 +368,7 @@ const GalleryPage = () => {
             variant={showBookmarks ? "secondary" : "outline"}
             onClick={handleBookmarkFilter}
           >
-            <BookmarkIcon className="mr-2 h-4 w-4" />
+            {showBookmarks ? <BookmarkFilledIcon className="mr-2 h-4 w-4" /> : <BookmarkIcon className="mr-2 h-4 w-4" />}
             Only Bookmarks
           </Button>
           <div className="flex items-center space-x-2 p-2">

--- a/web/ui/src/pages/gallery/Gallery.tsx
+++ b/web/ui/src/pages/gallery/Gallery.tsx
@@ -40,6 +40,7 @@ const GalleryPage = () => {
   const statusFilter = searchParams.get("status") || "";
   // toggles
   const perceptionGroup = searchParams.get("perception") === "true";
+  const showBookmarks = searchParams.get("bookmarked") === "true";
   const showFailed = searchParams.get("failed") !== "false"; // Default to true
 
   useEffect(() => {
@@ -49,9 +50,9 @@ const GalleryPage = () => {
   useEffect(() => {
     getData(
       setLoading, setGallery, setTotalPages,
-      page, limit, technologyFilter, statusFilter, perceptionGroup, showFailed
+      page, limit, technologyFilter, statusFilter, perceptionGroup, showFailed, showBookmarks
     );
-  }, [page, limit, perceptionGroup, statusFilter, technologyFilter, showFailed]);
+  }, [page, limit, perceptionGroup, statusFilter, technologyFilter, showFailed, showBookmarks]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -125,6 +126,13 @@ const GalleryPage = () => {
       return prev;
     });
   };
+
+  const handleBookmarkFilter = () => {
+    setSearchParams(prev => {
+      prev.set("bookmarked", (!showBookmarks).toString());
+      return prev
+    })
+  }
 
   const handleToggleShowFailed = () => {
     setSearchParams(prev => {
@@ -355,6 +363,13 @@ const GalleryPage = () => {
           >
             <GroupIcon className="mr-2 h-4 w-4" />
             Group by Similar
+          </Button>
+          <Button
+            variant={showBookmarks ? "secondary" : "outline"}
+            onClick={handleBookmarkFilter}
+          >
+            <BookmarkIcon className="mr-2 h-4 w-4" />
+            Only Bookmarks
           </Button>
           <div className="flex items-center space-x-2 p-2">
             <Switch

--- a/web/ui/src/pages/gallery/Gallery.tsx
+++ b/web/ui/src/pages/gallery/Gallery.tsx
@@ -25,7 +25,7 @@ import { Switch } from "@/components/ui/switch";
 
 
 const GalleryPage = () => {
-  const [gallery, setGallery] = useState<apitypes.galleryResult[]>();
+  const [gallery, setGallery] = useState<apitypes.galleryResult[]>([]);
   const [wappalyzer, setWappalyzer] = useState<apitypes.wappalyzer>();
   const [technology, setTechnology] = useState<apitypes.technologylist>();
   const [totalPages, setTotalPages] = useState(0);
@@ -136,12 +136,11 @@ const GalleryPage = () => {
   const handleBookmarkClick = async (id: number) => {
     const bookmarkUpdated = await bookmarkResult(id)
     if (bookmarkUpdated) {
-      setGallery((prevGallery) => {
-        if (!prevGallery) { return []; }  // Necessary due to the gallery state not being defined on initialization and as such could potentially be undefined
+      setGallery((prevGallery) => 
         prevGallery.map((item) =>
           item.id === id ? { ...item, bookmarked: !item.bookmarked } : item
         )
-      });
+      );
     }
   }
 

--- a/web/ui/src/pages/gallery/Gallery.tsx
+++ b/web/ui/src/pages/gallery/Gallery.tsx
@@ -8,6 +8,7 @@ import {
   AlertOctagonIcon, BanIcon, CheckIcon, ChevronLeftIcon, ChevronRightIcon, ClockIcon, ExternalLinkIcon,
   FilterIcon, GroupIcon, ShieldCheckIcon, XIcon
 } from "lucide-react";
+import { BookmarkIcon, BookmarkFilledIcon } from "@radix-ui/react-icons";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -17,6 +18,7 @@ import { cn } from "@/lib/utils";
 import * as api from "@/lib/api/api";
 import * as apitypes from "@/lib/api/types";
 import { getData, getWappalyzerData } from "./data";
+import { bookmarkResult } from "@/lib/api/bookmark";
 import { getIconUrl, getStatusColor } from "@/lib/common";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -131,6 +133,18 @@ const GalleryPage = () => {
     });
   };
 
+  const handleBookmarkClick = async (id: number) => {
+    const bookmarkUpdated = await bookmarkResult(id)
+    if (bookmarkUpdated) {
+      setGallery((prevGallery) => {
+        if (!prevGallery) { return []; }  // Necessary due to the gallery state not being defined on initialization and as such could potentially be undefined
+        prevGallery.map((item) =>
+          item.id === id ? { ...item, bookmarked: !item.bookmarked } : item
+        )
+      });
+    }
+  }
+
   const sortedTechnologies = useMemo(() => {
     if (!technology) return [];
     const selectedTechnologies = technologyFilter.split(',').filter(Boolean);
@@ -196,21 +210,32 @@ const GalleryPage = () => {
           </CardContent>
 
           <CardFooter className="p-2 flex flex-col items-start">
-            <div className="w-full mb-2">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="w-full truncate text-sm font-medium">
-                      {screenshot.title || "Untitled"}
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{screenshot.title || "Untitled"}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <div className="w-full truncate text-xs text-muted-foreground mt-1">
-                {screenshot.url}
+            <div className="flex flex-row" style={{ width: "100%" }}>
+              <div className="w-full mb-2">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="w-full truncate text-sm font-medium">
+                        {screenshot.title || "Untitled"}
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>{screenshot.title || "Untitled"}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <div className="w-full truncate text-xs text-muted-foreground mt-1">
+                  {screenshot.url}
+                </div>
+              </div>
+              <div style={{ marginLeft: "auto"}} 
+                onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleBookmarkClick(screenshot.id);
+                  }}
+              >
+                {screenshot.bookmarked ? <BookmarkFilledIcon style={{ width: "24px", height: "24px"}}/>: <BookmarkIcon style={{ width: "24px", height: "24px"}}/>}
               </div>
             </div>
             <div className="w-full flex items-center justify-between mt-2">

--- a/web/ui/src/pages/gallery/data.tsx
+++ b/web/ui/src/pages/gallery/data.tsx
@@ -32,6 +32,7 @@ const getData = async (
   statusFilter: string,
   perceptionGroup: boolean,
   showFailed: boolean,
+  showBookmarks: boolean,
 ) => {
   setLoading(true);
   try {
@@ -42,6 +43,7 @@ const getData = async (
       status: statusFilter,
       perception: perceptionGroup ? 'true' : 'false',
       failed: showFailed ? 'true' : 'false',
+      bookmarked: showBookmarks ? true : false,
     });
     setGallery(s.results);
     setTotalPages(Math.ceil(s.total_count / limit));

--- a/web/ui/src/pages/gallery/data.tsx
+++ b/web/ui/src/pages/gallery/data.tsx
@@ -24,7 +24,7 @@ const getWappalyzerData = async (
 
 const getData = async (
   setLoading: React.Dispatch<React.SetStateAction<boolean>>,
-  setGallery: React.Dispatch<React.SetStateAction<apitypes.galleryResult[] | undefined>>,
+  setGallery: React.Dispatch<React.SetStateAction<apitypes.galleryResult[]>>,
   setTotalPages: React.Dispatch<React.SetStateAction<number>>,
   page: number,
   limit: number,


### PR DESCRIPTION
## Summary
Added a bookmarking feature and implemented it across the API, UI, and CLI. Allows user to bookmark a given result and then view and filter their results by bookmarks.

## Implementation Specifics
### Model
- Added a bookmarked boolean field to results that is true if a result is marked as bookmarked, false otherwise
### API
- Bookmarks API to toggle the bookmark status of a given result - inverts the current value allowing the use of a single endpoint for both bookmarking and un-bookmarking
- Added the bookmarked field to the list, search, and gallery API responses
- Gallery API supports filtering by bookmark status
### Web Components
- Bookmarked boolean value added to types
- Bookmark result component that updates the bookmark status for a given result ID
### Web UI
- Bookmark icon is from the radix icons - maintaining visual consistency with existing icon set
- All bookmark buttons are filled when the result is bookmarked and unfilled when not, and are updated dynamically
- Bookmark button on gallery cards
- Bookmark only filtering in the gallery view
- Bookmark button on detail page
- Bookmark button on overview page
- Bookmark filtering on overview page
### CLI
- Bookmarks filtering flag in report listing - allows you to view only results that are bookmarked

## Related Issues
The following are issues requesting this feature:
- #253 
- #271 

## Screenshots
<img width="1248" height="831" alt="image" src="https://github.com/user-attachments/assets/70ed8f24-31b3-4309-904f-add8e8d9da7e" />

<img width="1240" height="530" alt="image" src="https://github.com/user-attachments/assets/1d6d361b-3711-426c-9e58-8795c16d3bbd" />

<img width="1241" height="371" alt="image" src="https://github.com/user-attachments/assets/ffb0c9df-d477-4cb7-bc50-69f6370ca8fb" />

<img width="1246" height="569" alt="image" src="https://github.com/user-attachments/assets/aa41ae6f-a3ee-480e-ba15-767059b68826" />
