### PR TITLE
(feat) allow setting --host-resolver-rules

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -156,6 +156,7 @@ func init() {
 	// Chrome options
 	scanCmd.PersistentFlags().StringVar(&opts.Chrome.Path, "chrome-path", "", "The path to a Google Chrome binary to use (downloads a platform-appropriate binary by default)")
 	scanCmd.PersistentFlags().StringVar(&opts.Chrome.Proxy, "chrome-proxy", "", "An HTTP/SOCKS5 proxy server to use. Specify the proxy using this format: proto://address:port")
+	scanCmd.PersistentFlags().StringVar(&opts.Chrome.HostResolverRules, "chrome-host-resolver-rules", "", "Host resolver rules to pass through to Chrome using the --host-resolver-rules option")
 	scanCmd.PersistentFlags().StringVar(&opts.Chrome.WSS, "chrome-wss-url", "", "A websocket URL to connect to a remote, already running Chrome DevTools instance (i.e., Chrome started with --remote-debugging-port)")
 	scanCmd.PersistentFlags().StringVar(&opts.Chrome.UserAgent, "chrome-user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36", "The user-agent string to use")
 	scanCmd.PersistentFlags().IntVar(&opts.Chrome.WindowX, "chrome-window-x", 1280, "The Chrome browser window width, in pixels")

--- a/pkg/runner/drivers/chromedp.go
+++ b/pkg/runner/drivers/chromedp.go
@@ -106,6 +106,11 @@ func getChromedpAllocator(opts runner.Options) (*browserInstance, error) {
 			allocOpts = append(allocOpts, chromedp.ProxyServer(opts.Chrome.Proxy))
 		}
 
+		// Add resolver rules if specified
+		if opts.Chrome.HostResolverRules != "" {
+			allocOpts = append(allocOpts, chromedp.Flag("host-resolver-rules", opts.Chrome.HostResolverRules))
+		}
+
 		// Use specific Chrome binary if provided
 		if opts.Chrome.Path != "" {
 			allocOpts = append(allocOpts, chromedp.ExecPath(opts.Chrome.Path))

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -33,6 +33,8 @@ type Chrome struct {
 	WSS string
 	// Proxy server to use
 	Proxy string
+	// Host resolver rules to pass to --host-resolver-rules
+	HostResolverRules string
 	// UserAgent is the user-agent string to set for Chrome
 	UserAgent string
 	// Headers to add to every request


### PR DESCRIPTION
I wanted to use this tool to test some reverse proxies that use split DNS, so I can't assume that the DNS host is available or pointing to the correct place.

To do this I have added a `--chrome-host-resolver-rules` option that passes through to the Chrome `--host-resolver-rules` option. The format of the rules are explained here:
https://chromium.googlesource.com/chromium/src/+/HEAD/net/dns/mapped_host_resolver.h#40

Here is an example where it is sending my request for `http://example.com` to `127.0.0.1:8000` and `https://example.com` to `127.0.0.1:8443` using the one rule:
```
# gowitness scan --chrome-host-resolver-rules "MAP example.com:80 127.0.0.1:8000,MAP example.com:443 127.0.0.1:8443" single -u http://example.com
# gowitness scan --chrome-host-resolver-rules "MAP example.com:80 127.0.0.1:8000,MAP example.com:443 127.0.0.1:8443" single -u https://example.com
```

I did some limited testing and Chrome appears to be sending the correct host header and SNI.

Thank you for this awesome project!