### PR TITLE
(fix) correct docker-compose gowitness command and traefik tls config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   gowitness:
     image: ghcr.io/sensepost/gowitness:latest
     restart: unless-stopped
-    command: gowitness report server --host 0.0.0.0 --screenshot-path /data/screenshots --db-uri sqlite:///data/gowitness.sqlite3
+    command: report server --host 0.0.0.0 --screenshot-path /data/screenshots --db-uri sqlite:///data/gowitness.sqlite3
     volumes:
       - ./gowitness.sqlite3:/data/gowitness.sqlite3
       - ./screenshots:/data/screenshots
@@ -12,7 +12,7 @@ services:
       traefik.enable: true
       traefik.http.routers.gowitness.rule: Host(`gowitness.local`)
       traefik.http.routers.gowitness.entryPoints: web-secure
-      traefik.http.routers.gowitness.tls.certResolver: default
+      traefik.http.routers.gowitness.tls: true
       traefik.http.routers.gowitness.middlewares: basic-auth
 
   traefik:


### PR DESCRIPTION
## What

Two fixes to `docker-compose.yml` that prevent the documented `docker compose up` flow from working:

1. **Duplicate `gowitness` subcommand** — the command was `gowitness report server ...`, but the image entrypoint is already the `gowitness` binary (`tini -- gowitness ...`). The result was `unknown command "gowitness" for "gowitness"` and the container crash-looping. Fixed to `report server ...`.

2. **Broken Traefik TLS config** — the router referenced `tls.certResolver: default`, but no cert resolver is configured in the compose file, so Traefik errored with `Router uses a nonexistent certificate resolver`. Replaced with `tls: true`, letting Traefik terminate TLS with its built-in self-signed cert.

## Motivation

Following the repo's own `docker-compose.yml`, the gowitness container never starts (crash loop) and the Traefik router never matches, so the UI at `https://gowitness.local` returns 404.

## Testing

With these changes, `docker compose up -d` brings both containers up; `curl -k https://gowitness.local` returns `401` (basic auth) and `200` with credentials.