### PR TITLE
(feat) add --chrome-user-data-dir to reuse an existing chrome profile

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -156,6 +156,7 @@ func init() {
 	// Chrome options
 	scanCmd.PersistentFlags().StringVar(&opts.Chrome.Path, "chrome-path", "", "The path to a Google Chrome binary to use (downloads a platform-appropriate binary by default)")
 	scanCmd.PersistentFlags().StringVar(&opts.Chrome.Proxy, "chrome-proxy", "", "An HTTP/SOCKS5 proxy server to use. Specify the proxy using this format: proto://address:port")
+	scanCmd.PersistentFlags().StringVar(&opts.Chrome.UserDataDir, "chrome-user-data-dir", "", "A Chrome user data directory to use instead of a temporary one. Point this at an existing profile (e.g. ~/.config/google-chrome) to reuse logged in sessions. The directory is left in place after the scan")
 	scanCmd.PersistentFlags().StringVar(&opts.Chrome.WSS, "chrome-wss-url", "", "A websocket URL to connect to a remote, already running Chrome DevTools instance (i.e., Chrome started with --remote-debugging-port)")
 	scanCmd.PersistentFlags().StringVar(&opts.Chrome.UserAgent, "chrome-user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36", "The user-agent string to use")
 	scanCmd.PersistentFlags().IntVar(&opts.Chrome.WindowX, "chrome-window-x", 1280, "The Chrome browser window width, in pixels")

--- a/pkg/runner/drivers/chromedp.go
+++ b/pkg/runner/drivers/chromedp.go
@@ -53,6 +53,9 @@ type browserInstance struct {
 	allocCtx    context.Context
 	allocCancel context.CancelFunc
 	userData    string
+	// ephemeralUserData is true when gowitness created the user data
+	// directory itself. A user supplied directory is left in place.
+	ephemeralUserData bool
 }
 
 // Close closes the allocator, and cleans up the user dir.
@@ -60,8 +63,8 @@ func (b *browserInstance) Close() {
 	b.allocCancel()
 	<-b.allocCtx.Done()
 
-	// cleanup the user data directory
-	if b.userData != "" {
+	// cleanup the user data directory, but only if we created it
+	if b.ephemeralUserData && b.userData != "" {
 		os.RemoveAll(b.userData)
 	}
 }
@@ -72,11 +75,12 @@ func getChromedpAllocator(opts runner.Options) (*browserInstance, error) {
 		allocCtx    context.Context
 		allocCancel context.CancelFunc
 		userData    string
+		ephemeral   bool
 		err         error
 	)
 
 	if opts.Chrome.WSS == "" {
-		userData, err = os.MkdirTemp("", "gowitness-v3-chromedp-*")
+		userData, ephemeral, err = resolveUserDataDir(opts.Chrome.UserDataDir, "gowitness-v3-chromedp-*")
 		if err != nil {
 			return nil, err
 		}
@@ -129,9 +133,10 @@ func getChromedpAllocator(opts runner.Options) (*browserInstance, error) {
 	}
 
 	return &browserInstance{
-		allocCtx:    allocCtx,
-		allocCancel: allocCancel,
-		userData:    userData,
+		allocCtx:          allocCtx,
+		allocCancel:       allocCancel,
+		userData:          userData,
+		ephemeralUserData: ephemeral,
 	}, nil
 }
 

--- a/pkg/runner/drivers/go-rod.go
+++ b/pkg/runner/drivers/go-rod.go
@@ -29,6 +29,9 @@ type Gorod struct {
 	browser *rod.Browser
 	// user data directory
 	userData string
+	// ephemeralUserData is true when gowitness created the user data
+	// directory itself. A user supplied directory is left in place.
+	ephemeralUserData bool
 	// options for the Runner to consider
 	options runner.Options
 	// logger
@@ -39,13 +42,14 @@ type Gorod struct {
 // It's up to the caller to call Close() on the instance.
 func NewGorod(logger *slog.Logger, opts runner.Options) (*Gorod, error) {
 	var (
-		url      string
-		userData string
-		err      error
+		url       string
+		userData  string
+		ephemeral bool
+		err       error
 	)
 
 	if opts.Chrome.WSS == "" {
-		userData, err = os.MkdirTemp("", "gowitness-v3-gorod-*")
+		userData, ephemeral, err = resolveUserDataDir(opts.Chrome.UserDataDir, "gowitness-v3-gorod-*")
 		if err != nil {
 			return nil, err
 		}
@@ -117,10 +121,11 @@ func NewGorod(logger *slog.Logger, opts runner.Options) (*Gorod, error) {
 	}
 
 	return &Gorod{
-		browser:  browser,
-		userData: userData,
-		options:  opts,
-		log:      logger,
+		browser:           browser,
+		userData:          userData,
+		ephemeralUserData: ephemeral,
+		options:           opts,
+		log:               logger,
 	}, nil
 }
 
@@ -500,8 +505,8 @@ func (run *Gorod) Close() {
 		return
 	}
 
-	// cleaning user data
-	if run.userData != "" {
+	// cleaning user data, but only if we created it
+	if run.ephemeralUserData && run.userData != "" {
 		// wait a sec for the browser process to go away
 		time.Sleep(time.Second * 1)
 

--- a/pkg/runner/drivers/userdata.go
+++ b/pkg/runner/drivers/userdata.go
@@ -1,0 +1,21 @@
+package driver
+
+import "os"
+
+// resolveUserDataDir decides which Chrome user data directory a driver should
+// use. When configured is empty a fresh temporary directory is created and
+// returned with ephemeral set to true, so the caller knows to remove it when
+// the browser closes. When the user pointed us at their own directory it is
+// returned as is with ephemeral false, so we never delete a real profile.
+func resolveUserDataDir(configured, pattern string) (dir string, ephemeral bool, err error) {
+	if configured != "" {
+		return configured, false, nil
+	}
+
+	dir, err = os.MkdirTemp("", pattern)
+	if err != nil {
+		return "", false, err
+	}
+
+	return dir, true, nil
+}

--- a/pkg/runner/drivers/userdata_test.go
+++ b/pkg/runner/drivers/userdata_test.go
@@ -1,0 +1,41 @@
+package driver
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveUserDataDirCreatesTempWhenEmpty(t *testing.T) {
+	dir, ephemeral, err := resolveUserDataDir("", "gowitness-test-*")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ephemeral {
+		t.Fatalf("expected an ephemeral directory when none was configured")
+	}
+	if dir == "" {
+		t.Fatal("expected a temporary directory path, got an empty string")
+	}
+	defer os.RemoveAll(dir)
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("expected the temporary directory to exist: %v", err)
+	}
+}
+
+func TestResolveUserDataDirKeepsConfigured(t *testing.T) {
+	// a directory the user supplied should be returned untouched and never
+	// flagged for cleanup, so we don't wipe someone's real Chrome profile.
+	configured := t.TempDir()
+
+	dir, ephemeral, err := resolveUserDataDir(configured, "gowitness-test-*")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ephemeral {
+		t.Fatal("a configured directory should not be marked ephemeral")
+	}
+	if dir != configured {
+		t.Fatalf("expected %q, got %q", configured, dir)
+	}
+}

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -33,6 +33,12 @@ type Chrome struct {
 	WSS string
 	// Proxy server to use
 	Proxy string
+	// UserDataDir is a Chrome user data directory to use instead of a
+	// throwaway temporary one. Point this at an existing profile (for
+	// example ~/.config/google-chrome) to reuse logged in sessions.
+	// When empty, a fresh temporary directory is created per run and
+	// removed on exit.
+	UserDataDir string
 	// UserAgent is the user-agent string to set for Chrome
 	UserAgent string
 	// Headers to add to every request


### PR DESCRIPTION
Closes #257.

Both drivers spin up a throwaway user data dir per run, so there's no way to point gowitness at an existing Chrome profile when you want to screenshot pages that sit behind a login. This adds a `--chrome-user-data-dir` flag that hands Chrome a directory you choose instead.

When the flag is set gowitness uses that directory as is and leaves it in place on exit. Without it nothing changes, a temp dir is still created and cleaned up like before. I pulled the temp-vs-supplied decision into a small helper so the chromedp and go-rod drivers behave the same way, and the guard means we never delete a real profile on close.

Tested both drivers against a live target with `--chrome-user-data-dir` pointing at a profile dir and confirmed the profile is kept afterwards, and that a normal run with no flag still creates and removes its temp dir.
