### PR TITLE
Fix screenshot filename truncation

### DIFF
--- a/internal/islazy/string.go
+++ b/internal/islazy/string.go
@@ -1,10 +1,33 @@
 package islazy
 
-// LeftTrucate a string if its more than max
-func LeftTrucate(s string, max int) string {
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"unicode/utf8"
+)
+
+// Truncate shortens s to at most max bytes, keeping the start of the string.
+//
+// When s has to be shortened a short hash of the full value is appended, so
+// that two values which only differ past the cut do not collapse onto the
+// same result.
+func Truncate(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
 
-	return s[max:]
+	sum := sha256.Sum256([]byte(s))
+	suffix := "-" + hex.EncodeToString(sum[:])[:8]
+
+	keep := max - len(suffix)
+	if keep < 0 {
+		keep = 0
+	}
+
+	// never slice through a multi byte rune
+	for keep > 0 && !utf8.RuneStart(s[keep]) {
+		keep--
+	}
+
+	return s[:keep] + suffix
 }

--- a/internal/islazy/string_test.go
+++ b/internal/islazy/string_test.go
@@ -1,0 +1,40 @@
+package islazy
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateLeavesShortStringsAlone(t *testing.T) {
+	if got := Truncate("short", 200); got != "short" {
+		t.Errorf("expected the input unchanged, got %q", got)
+	}
+}
+
+func TestTruncateBoundsTheLength(t *testing.T) {
+	if got := Truncate(strings.Repeat("a", 5000), 200); len(got) > 200 {
+		t.Errorf("expected at most 200 bytes, got %d", len(got))
+	}
+}
+
+func TestTruncateKeepsTheStartOfTheString(t *testing.T) {
+	got := Truncate("https---example.com-443"+strings.Repeat("a", 500), 200)
+	if !strings.HasPrefix(got, "https---example.com-443") {
+		t.Errorf("expected the identifying prefix to survive, got %q", got)
+	}
+}
+
+func TestTruncateSeparatesValuesSharingAPrefix(t *testing.T) {
+	prefix := strings.Repeat("a", 300)
+
+	if Truncate(prefix+"one", 200) == Truncate(prefix+"two", 200) {
+		t.Error("expected values differing past the cut to truncate differently")
+	}
+}
+
+func TestTruncateDoesNotSplitRunes(t *testing.T) {
+	if got := Truncate(strings.Repeat("ä", 500), 200); !utf8.ValidString(got) {
+		t.Errorf("expected valid utf8, got %q", got)
+	}
+}

--- a/pkg/runner/drivers/chromedp.go
+++ b/pkg/runner/drivers/chromedp.go
@@ -522,8 +522,9 @@ func (run *Chromedp) Witness(target string, thisRunner *runner.Runner) (*models.
 
 		// write the screenshot to disk if we have a path
 		if !run.options.Scan.ScreenshotSkipSave {
-			result.Filename = islazy.SafeFileName(target) + "." + run.options.Scan.ScreenshotFormat
-			result.Filename = islazy.LeftTrucate(result.Filename, 200)
+			// bound the name only, so that the extension always survives
+			result.Filename = islazy.Truncate(islazy.SafeFileName(target), 200) +
+				"." + run.options.Scan.ScreenshotFormat
 			if err := os.WriteFile(
 				filepath.Join(run.options.Scan.ScreenshotPath, result.Filename),
 				img, os.FileMode(0664),

--- a/pkg/runner/drivers/go-rod.go
+++ b/pkg/runner/drivers/go-rod.go
@@ -464,8 +464,9 @@ func (run *Gorod) Witness(target string, runner *runner.Runner) (*models.Result,
 
 		// write the screenshot to disk if we have a path
 		if !run.options.Scan.ScreenshotSkipSave {
-			result.Filename = islazy.SafeFileName(target) + "." + run.options.Scan.ScreenshotFormat
-			result.Filename = islazy.LeftTrucate(result.Filename, 200)
+			// bound the name only, so that the extension always survives
+			result.Filename = islazy.Truncate(islazy.SafeFileName(target), 200) +
+				"." + run.options.Scan.ScreenshotFormat
 			if err := os.WriteFile(
 				filepath.Join(run.options.Scan.ScreenshotPath, result.Filename),
 				img, os.FileMode(0664),


### PR DESCRIPTION
`islazy.LeftTruncate` returns `s[max:]`, the part of the string *after* `max` bytes, not the first `max` bytes. Three consequences, all visible in `scan`:

- **It never bounds the length**: A 900 byte name comes back 700 byte long, so #202 is still reproducable. A URL past roughly 455  characters fails with `could not write screenshot to disk: open ...: file name to long`, the whole result is dropped, and nothing is logged unless `--log-scan-errors` is set.
- **It keeps the wrong half**: For URLs between ~200 and ~455 characters the write succeeds but the same scheme and host are discared and only the query-string tail survives. Scanning `http://host/?q=aaaa...` produced `aaaa...jpg`, no host unidentifiable, and two long URLs sharing a tail collide. That works against #242, where filenames were deliberately made parseable.
- **It slices by byte**: `SafeFileName` keeps non-ASCII letters, so the cut can land inside a multi-byte rune and produce and invalid UTF-8 filename.

Replaced with `islazy.Truncate`, which keeps the start of the string, stays within the limit, and appends a short hash of the full value so names that only differ past the cut stay distinct. The extension is now appended after truncation instead of being part of what gets cut.

Filenames shorter than the limit are completely unaffected.

Adds unit tests for `islazy.Truncate` covering the length bound, prefix preservation, prefix-sharing inputs, and rune safety.