### PR TITLE
CI: migrate deprecated ::set-output to $GITHUB_OUTPUT and bump checkout to v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,11 +11,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: Publish latest tag to Github Repo (only on master branch push)


### PR DESCRIPTION
## What
`.github/workflows/docker.yml` uses the deprecated workflow command `echo ::set-output name=VERSION::...` and pins `actions/checkout@v2`.

## Why
GitHub has deprecated the `::set-output` command in favour of writing to the `$GITHUB_OUTPUT` file, and `checkout@v2` runs on the deprecated Node.js 16 runtime. Both produce deprecation annotations and are on a removal path.

## Change
- Migrate the version step to `echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"`. The downstream `steps.get_version.outputs.VERSION` references are unchanged, so the published image tags stay the same.
- Bump `actions/checkout@v2` to `@v4` (Node 20).

YAML validated; one file.